### PR TITLE
Use thread-specific filenames

### DIFF
--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -40,7 +40,7 @@ def check_backup(backup_dir):
     # We have only ever seen database version 23, so we don't proceed if it's
     # not that. Testing and pull requests welcome.
     version = version_str.split(":")[-1].strip()
-    if not version in ["23", "65", "80"]:
+    if not version in ["23", "65", "80", "89"]:
         warnings.warn(
             f"Warning: Found untested Signal database version: {version}."
         )
@@ -81,7 +81,7 @@ def make_recipient_v23(db, recipient_id):
 
 
 def make_recipient_v80(db, recipient_id):
-    """Create a Recipient instance from a recipient id (db version 65, 80)"""
+    """Create a Recipient instance from a recipient id (db version 65, 80, 89)"""
     qry = db.execute(
         "SELECT group_id, phone, system_display_name, profile_joined_name, color from recipient where _id=?",
         (recipient_id,),
@@ -116,7 +116,7 @@ def make_recipient_v80(db, recipient_id):
 def make_recipient(db, recipient_id, version=None):
     if version == "23":
         return make_recipient_v23(db, recipient_id)
-    elif version in ["65", "80"]:
+    elif version in ["65", "80", "89"]:
         return make_recipient_v80(db, recipient_id)
     else:
         warnings.warn(

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -180,8 +180,10 @@ def dump_thread(thread, output_dir):
 
     os.makedirs(output_dir, exist_ok=True)
 
+    # Use phone number to distinguish threads from the same contact,
+    # except for groups, which do not have a phone number.
     filename = os.path.join(
-        output_dir, thread.name.replace(" ", "_") + ".html"
+        output_dir, ( thread.sanename if thread.recipient.isgroup else thread.sanephone ) + ".html"
     )
     with open(filename, "w", encoding="utf-8") as fp:
         fp.write(html)

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -14,7 +14,8 @@ Author: Gertjan van den Burg
 from abc import ABCMeta
 from dataclasses import dataclass, field
 from typing import List
-
+from re import sub
+from unicodedata import normalize
 
 @dataclass
 class RecipientId:
@@ -48,6 +49,7 @@ class Recipient:
     name: str
     color: str
     isgroup: bool
+    phone: str
 
     def __hash__(self):
         return hash(self.recipientId)
@@ -88,5 +90,26 @@ class Thread:
     sms: List[SMSMessageRecord] = field(default_factory=lambda: [])
 
     @property
+    def sanephone(self):
+        """Return a sanitized phone number suitable for use as filename, and fallback on rid.
+
+        NOTE: Phone numbers can be alphanumerical characters especially coming over SMS
+        Different strings can still clash in principle if they sanitize to the same string.
+        """
+        if self.recipient.phone:
+            return sub('[^]\\w!@#$%^&\'`.=+{}~()[-]', '_', normalize('NFKC', self.recipient.phone.strip()).lstrip(".#"))
+        else:
+            return '#' + self.recipient.recipientId._id
+
+    @property
     def name(self):
+        """Return the raw name or other useful identifier, suitable for display."""
         return self.recipient.name.strip()
+
+    @property
+    def sanename(self):
+        """Return a sanitized name or other useful identifier, suitable for use as filename, and fallback on rid."""
+        if self.recipient.name:
+            return sub('[^]\\w!@#$%^&\'`.=+{}~()[-]', '_', normalize('NFKC', self.recipient.name.strip()).lstrip(".#"))
+        else:
+            return '#' + self.recipient.recipientId._id

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -97,7 +97,7 @@ class Thread:
         Different strings can still clash in principle if they sanitize to the same string.
         """
         if self.recipient.phone:
-            return sub('[^]\\w!@#$%^&\'`.=+{}~()[-]', '_', normalize('NFKC', self.recipient.phone.strip()).lstrip(".#"))
+            return self._sanitize(self.recipient.phone)
         else:
             return '#' + self.recipient.recipientId._id
 
@@ -110,6 +110,14 @@ class Thread:
     def sanename(self):
         """Return a sanitized name or other useful identifier, suitable for use as filename, and fallback on rid."""
         if self.recipient.name:
-            return sub('[^]\\w!@#$%^&\'`.=+{}~()[-]', '_', normalize('NFKC', self.recipient.name.strip()).lstrip(".#"))
+            return self._sanitize(self.recipient.name)
         else:
             return '#' + self.recipient.recipientId._id
+
+    def _sanitize(self, text):
+        """Sanitize text to use as filename"""
+        clean = normalize('NFKC', text.strip())
+        clean = clean.lstrip(".#")
+        clean = sub('[^]\\w!@#$%^&\'`.=+{}~()[-]', '_', clean)
+        return clean
+


### PR DESCRIPTION
This PR solves the following problems:

1. Avoid clobbering files when a contact has several threads. This happens when a contact has several phone numbers and messages were exchanged on several of those numbers. To avoid overwriting the first thread with further threads, the created file structure is now <contact>/<phone>.html instead of <contact>/<contact>.html (except for groups, which have no phone).
2. Use phone number as fallback when the contact has no name. Note that phone numbers can be alphanumerical strings for messages received by SMS.
3. Sanitize contact names and phone numbers that are used as file names.
    - Perform unicode normalization to use canonical characters.
    - Strip leading/ending space characters.
    - Remove leading '.' which cause file to be hidden on unix/linux (or reference special '.'/'..').
    - Only accept word characters plus some symbols. There is a bit of subjectivity in terms of which symbols to accept; I essentially added those that are legal in e-mail addresses (https://en.wikipedia.org/wiki/Email_address#Local-part). This definitely excludes smileys, drawing characters, control characters, path/pipe characters, spacing, etc. The original code only restricted spaces (not all spacing such as tabs, etc.) but I'm not sure why.
    - Remove leading '#' as it may clash with the use of '#'+recipient_id fallback. Use '#' before recipient ID to make it clear this is not a phone (or contact name).
4. Additional bug fix: tolerate references to groups not present in the groups table.

This was tested using a DB with version 89 (only). In terms of DB queries this newly assumes the presence of the 'phone' column in the 'recipient' table.