### PR TITLE
Support webp attachments (stickers) and fallback to download link

### DIFF
--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -3,18 +3,22 @@
     {% if attach.voiceNote %}
       <audio controls>
         <source src="{{ attach.fileName }}" type="{{ attach.contentType }}">
+        Audio of type {{ attach.contentType }} <span class="msg-dl-link"><a href="{{ attach.fileName }}" type="{{ attach.contentType }}">&#x2913;</a></span>
       </audio>
     {% elif attach.contentType == "video/mp4" or attach.contentType == "video/3gpp" %}
       <video controls>
         <source src="{{ attach.fileName }}" type="{{ attach.contentType }}">
+        Video of type {{ attach.contentType }} <span class="msg-dl-link"><a href="{{ attach.fileName }}" type="{{ attach.contentType }}">&#x2913;</a></span>
       </video>
-    {% elif attach.contentType == "image/jpeg" or attach.contentType == "image/png" or attach.contentType == "image/gif" %}
+    {% elif attach.contentType == "image/jpeg" or attach.contentType == "image/png" or attach.contentType == "image/gif" or attach.contentType == "image/webp" %}
     <div class="msg-img-container">
       <input type="checkbox" id="zoomCheck-{{ attach.unique_id }}">
       <label for="zoomCheck-{{ attach.unique_id }}">
         <img src="{{ attach.fileName }}">
       </label>
     </div>
+    {% else %}
+      Attachment of type {{ attach.contentType }} <span class="msg-dl-link"><a href="{{ attach.fileName }}" type="{{ attach.contentType }}" download>&#x2913;</a></span>
     {% endif %}
   </div>
 {%- endmacro %}
@@ -78,6 +82,11 @@
         font-size: x-small;
         opacity: 50%;
         align-self: center;
+      }
+
+      .msg-dl-link a {
+        font-size: xx-large;
+        text-decoration: none;
       }
 
       .msg-name {


### PR DESCRIPTION
Hi @GjjvdBurg 

This PR is about better presentation of attachments:
- add webp to allowed image types (used commonly for displaying stickers)
- provide fallback links for unknown types of attachments.
- provide fallback links after `<source>` for attachments the browser doesn't support -- not sure how widely that part of the spec is implemented: for example for audio/amr, Firefox displays non-working controls instead of the fallback text, so I left out the audio/amr type from the audio list and a download link will be displayed every time.

I have a few more fixes in preparation (for the same file). Do you prefer one PR for all (in which case I will simply keep adding stuff to this PR and edit the description), or very fine-grained PRs (in which case the 'draft' designation can be removed and this can be merged)?
