### PR TITLE
Bugfix/message quoting

### DIFF
--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -64,6 +64,13 @@
         padding: 10px;
       }
 
+      .msg pre {
+        font-family: Noto Sans, Liberation Sans, OpenSans, sans-serif;
+        white-space: pre-wrap;
+        margin-top: 0px;
+        margin-bottom: 5px;
+      }
+
       .msg-date {
         font-size: x-small;
         opacity: 50%;
@@ -215,7 +222,7 @@
           <div class="msg-quote">
             <div class="msg-quote-message">
               <span class="msg-name">{{ msg.quote.name }}</span>
-              <p>{{ msg.quote.body | safe }}</p>
+              <pre>{{ msg.quote.body | safe }}</pre>
             </div>
             {% if msg.quote.attachments %}
               <div class="msg-quote-attach">
@@ -236,12 +243,12 @@
          {% endif %}
          {% if msg.body %}
           {% if msg.isAllEmoji %}
-            <p class="msg-all-emoji">
+            <div class="msg-all-emoji">
           {% else %}
-            <p>
+            <div>
           {% endif %}
-          {{ msg.body | safe }}
-          </p>
+          <pre>{{ msg.body | safe }}</pre>
+          </div>
          {% endif %}
          <span class="msg-date">{{ msg.date.strftime('%b %d, %H:%M') }}</span>
        </div>


### PR DESCRIPTION
Hi

This PR includes some related fixes for message rendering.

- Process multi-char emoji. Previously, only the first char of an emoji was skipped once the emoji was written in the `<span>`, which lead to strange results for multi-char emojis. For example, a base emoji followed by a skin-tone modifier would show the combined emoji and then the skin-tone modifier by itself.
- Escape HTML chars `<`, `&`, `>` to prevent messages from introducing entities and tags. This has potential security implications, e.g. if an attacker sends a `<script>`: although harmless within the signal app (and weird looking), if unnoticed could execute in the context of a signal2html-produced local file.
- Use `<pre>` to format messages, in order to keep the original spacing and line breaks. Added style to keep wrapping and a proportional font.