### PR TITLE
Feature/gen contacts once

### DIFF
--- a/signal2html/__main__.py
+++ b/signal2html/__main__.py
@@ -8,6 +8,7 @@ Copyright: 2020, G.J.J. van den Burg
 """
 
 import sys
+import logging
 
 
 def main():
@@ -17,4 +18,5 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/signal2html/addressbook.py
+++ b/signal2html/addressbook.py
@@ -1,0 +1,224 @@
+"""Addressbook functionality
+
+License: See LICENSE file.
+
+"""
+
+import logging
+import sqlite3
+
+from enum import Enum
+
+from .html_colors import get_random_color
+from .models import Recipient
+
+
+class Addressbook(object):
+    def __init__(self, db, version):
+        self.logger = logging.getLogger(__name__)
+        self.db = db
+        self.version = int(version)
+        self.rid_to_recipient: dict[str, Recipient] = {}
+        self.phone_to_rid: dict[str, str] = {}
+        self.groups: dict[int, str] = {}
+
+        self._load_groups()
+        self._load_recipients()
+        self.next_rid = 10000
+
+    def _add_recipient(self, recipient_id, name, color, isgroup, phone):
+        recipient = Recipient(
+            recipient_id, name=name, color=color, isgroup=isgroup, phone=phone
+        )
+
+        self.rid_to_recipient[str(recipient_id)] = recipient
+        self.logger.debug(
+            f"Adding recipient {str(recipient_id)} and phone {phone}"
+        )
+        if phone:
+            self.phone_to_rid[str(phone)] = str(recipient_id)
+
+        return recipient
+
+    def _get_friendly_name_for_group(self, address: str):
+        name = self.get_group_title(address)
+        if not name:
+            gid = self._get_group_id(address)
+            if gid:
+                return f"Group {gid}"
+            else:
+                return ""
+
+    def _get_group_id(self, group_id: str) -> str:
+        qry = self.db.execute(
+            "SELECT group_id, _id FROM groups WHERE group_id LIKE ?",
+            (f"{group_id}",),
+        )
+        qry_res = qry.fetchone()
+        if qry_res:
+            return str(qry_res[1])
+
+    def _get_new_rid(self) -> str:
+        while self.rid_to_recipient.get(str(self.next_rid)):
+            self.next_rid += 1
+
+        return str(self.next_rid)
+
+    def _get_unique_group_id(self, group_id: str) -> str:
+        return group_id
+
+    def _load_groups(self):
+        qry = self.db.execute("SELECT group_id, title FROM groups")
+        qry_res = qry.fetchall()
+        for group_id, title in qry_res:
+            self.groups[self._get_unique_group_id(group_id)] = title
+
+    def get_group_title(self, group_id: str) -> str:
+        return self.groups.get(group_id)
+
+    def get_recipient_by_phone(self, phone: str) -> Recipient:
+        rid = self.phone_to_rid.get(phone)
+        return self.rid_to_recipient.get(rid)
+
+
+class AddressbookV1(Addressbook):
+    def _isgroup(self, address: str) -> bool:
+        return address.startswith(
+            "__textsecure_group__"
+        ) or address.startswith("__signal_mms_group__")
+
+    def _load_recipients(self):
+        qry = self.db.execute(
+            "SELECT _id, recipient_ids, system_display_name, color, signal_profile_name "
+            "FROM recipient_preferences "
+        )
+        qry_res = qry.fetchall()
+
+        for (
+            recipient_id,
+            phone,
+            system_display_name,
+            color,
+            profile_name,
+        ) in qry_res:
+            isgroup = self._isgroup(phone)
+            if isgroup:
+                phone = self._get_unique_group_id(phone)
+                name = self.get_group_title(phone)
+                if name is None:
+                    name = self._get_friendly_name_for_group(phone)
+                    self.logger.warn(
+                        f"Group for recipient {recipient_id} will be named '{name}'."
+                    )
+            else:
+                name = system_display_name or profile_name or phone or ""
+
+            if color is None:
+                color = get_random_color()
+
+            self._add_recipient(recipient_id, name, color, isgroup, phone)
+
+    def get_recipient_by_address(self, address: str) -> Recipient:
+        isgroup = self._isgroup(address)
+        # For V1, address is a phone (or groupid)
+        if isgroup:
+            phone = self._get_unique_group_id(address)
+        else:
+            phone = address
+
+        rid = self.phone_to_rid.get(phone)
+        recipient = self.rid_to_recipient.get(rid)
+
+        if recipient is None:
+            # Create on the spot
+            newrid = self._get_new_rid()
+            if isgroup:
+                friendly_name = self._get_friendly_name_for_group(phone)
+                if friendly_name:
+                    self.logger.info(
+                        f"Group '{phone}' not in addressbook, adding it as '{friendly_name}'."
+                    )
+                else:
+                    self.logger.warn(
+                        f"Group '{phone}' not in addressbook, adding it with new ID {newrid}."
+                    )
+                return self._add_recipient(
+                    newrid, friendly_name, get_random_color(), True, phone
+                )
+            else:
+                self.logger.info(
+                    f"Recipient with phone '{address}' not in addressbook, adding it."
+                )
+                return self._add_recipient(
+                    newrid, address, get_random_color(), False, phone
+                )
+        else:
+            return recipient
+
+
+class AddressbookV2(Addressbook):
+    def _isgroup(self, group_id) -> bool:
+        return group_id is not None
+
+    def _load_recipients(self):
+        qry = self.db.execute(
+            "SELECT _id, group_id, "
+            "phone, "
+            "system_display_name, "
+            "profile_joined_name, "
+            "color "
+            "FROM recipient "
+        )
+        qry_res = qry.fetchall()
+        for (
+            recipient_id,
+            group_id,
+            phone,
+            system_display_name,
+            profile_joined_name,
+            color,
+        ) in qry_res:
+            isgroup = self._isgroup(group_id)
+            if isgroup:
+                name = self.get_group_title(group_id)
+                if name is None:
+                    name = self._get_friendly_name_for_group(group_id)
+                    if name:
+                        self.logger.info(
+                            f"Group for recipient {recipient_id} is '{group_id}' and will be called by group id using name '{name}'."
+                        )
+                    else:
+                        self.logger.warn(
+                            f"Group for recipient {recipient_id} is '{group_id}' which does not exist."
+                        )
+            else:
+                name = (
+                    system_display_name or profile_joined_name or phone or ""
+                )
+
+            if color is None:
+                color = get_random_color()
+
+            self._add_recipient(recipient_id, name, color, isgroup, phone)
+
+    def get_recipient_by_address(self, address: str) -> Recipient:
+        # For V2, address is a recipient_id
+        rid = address
+        recipient = self.rid_to_recipient.get(rid)
+
+        if recipient is None:
+            # Create on the spot, but not expected to happen
+            self.logger.warn(
+                f"Recipient with rid {address} not in addressbook, adding it."
+            )
+            return self._add_recipient(rid, "", get_random_color(), False, "")
+        else:
+            return recipient
+
+
+def make_addressbook(db, version):
+    """Factory function for Addressbook"""
+    if int(version) <= 23:
+        return AddressbookV1(db, version)
+    else:
+        return AddressbookV2(db, version)

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -70,8 +70,6 @@ def get_sms_records(db, thread, addressbook, version=None):
     qry_res = sms_qry.fetchall()
     for _id, address, date, date_sent, body, _type in qry_res:
         sms_auth = addressbook.get_recipient_by_address(address)
-        if sms_auth is None:
-            print(f"No author for address {address}")
         sms = SMSMessageRecord(
             _id=_id,
             addressRecipient=sms_auth,
@@ -208,14 +206,7 @@ def process_backup(backup_dir, output_dir):
     db_conn = sqlite3.connect(db_file)
     db = db_conn.cursor()
 
-    # Get and index all contact names
-    # groups_by_id = make_group_dict(db, version=db_version)
-
-    # rid_to_recipient: dict(str, Recipient) = {}
-    # phone_to_rid: dict(str, str) = {}
-    # make_addressbook(
-    #    db, db_version, groups_by_id, rid_to_recipient, phone_to_rid
-    # )
+    # Get and index all contact and group names
     addressbook: Addressbook = make_addressbook(db, db_version)
 
     # Start by getting the Threads from the database

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -141,17 +141,16 @@ def make_addressbook(
     db, version, groups_by_id, rid_to_recipient, phone_to_rid
 ):
     if version == "23":
-        return make_addressbook_v23(
-            db, version, groups_by_id, rid_to_recipient
-        )
+        make_addressbook_v23(db, version, groups_by_id, rid_to_recipient)
     elif version in ["65", "80", "89"]:
-        return make_addressbook_v80(
+        make_addressbook_v80(
             db, version, groups_by_id, rid_to_recipient, phone_to_rid
         )
-
-    return make_addressbook_v80(
-        db, groups_by_id, version, rid_to_recipient, phone_to_rid
-    )
+    else:
+        # Try latest version
+        make_addressbook_v80(
+            db, version, groups_by_id, rid_to_recipient, phone_to_rid
+        )
 
 
 def get_color(db, recipient_id):
@@ -399,10 +398,10 @@ def process_backup(backup_dir, output_dir):
 
     # Get and index all contact names
     groups_by_id = make_group_dict(db, version=db_version)
+
     rid_to_recipient: dict(str, Recipient) = {}
     phone_to_rid: dict(str, str) = {}
-
-    addressbook_by_rid = make_addressbook(
+    make_addressbook(
         db, db_version, groups_by_id, rid_to_recipient, phone_to_rid
     )
 

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -42,7 +42,7 @@ def check_backup(backup_dir):
     # We have only ever seen database version 23, so we don't proceed if it's
     # not that. Testing and pull requests welcome.
     version = version_str.split(":")[-1].strip()
-    if not version in ["23", "65", "80", "89"]:
+    if not version in ["18", "23", "65", "80", "89"]:
         warnings.warn(
             f"Warning: Found untested Signal database version: {version}."
         )

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -8,11 +8,12 @@ Copyright: 2020, G.J.J. van den Burg
 
 """
 
-import inspect
 import os
 import warnings
 import sqlite3
 import shutil
+
+from .addressbook import make_addressbook
 
 from .exceptions import DatabaseNotFound
 from .exceptions import DatabaseVersionNotFound
@@ -48,111 +49,6 @@ def check_backup(backup_dir):
     return version
 
 
-def make_group_dict(db, version):
-    groups = {}
-    qry = db.execute("SELECT group_id, title FROM groups")
-    qry_res = qry.fetchall()
-    for group_id, title in qry_res:
-        groups[group_id] = title
-
-    return groups
-
-
-def make_addressbook_v23(db, version, groups_by_id, rid_to_recipient):
-    qry = db.execute(
-        "SELECT recipient_ids, system_display_name, color "
-        "FROM recipient_preferences "
-    )
-    qry_res = qry.fetchall()
-    for recipient_id, system_display_name, color in qry_res:
-        if recipient_id.startswith("__textsecure_group__"):
-            name = groups_by_id.get(recipient_id)
-            isgroup = True
-            if name is None:
-                warnings.warn(
-                    f"Group for recipient {recipient_id} does not exist."
-                )
-        else:
-            name = system_display_name
-            isgroup = False
-
-        recipient_id = RecipientId(str(recipient_id))
-
-        if name is None:
-            name = ""
-
-        if color is None:
-            color = get_random_color()
-
-        rid_to_recipient[str(recipient_id)] = Recipient(
-            recipient_id, name=name, color=color, isgroup=isgroup, phone=""
-        )
-
-
-def make_addressbook_v80(
-    db, version, groups_by_id, rid_to_recipient, phone_to_rid
-):
-    qry = db.execute(
-        "SELECT _id, group_id, "
-        "phone, "
-        "system_display_name, "
-        "profile_joined_name, "
-        "color "
-        "FROM recipient "
-    )
-    qry_res = qry.fetchall()
-    for (
-        recipient_id,
-        group_id,
-        phone,
-        name,
-        profile_joined_name,
-        color,
-    ) in qry_res:
-        isgroup = group_id is not None
-        if isgroup:
-            name = groups_by_id.get(group_id)
-            if name is None:
-                warnings.warn(
-                    f"Group for recipient {recipient_id} is {group_id} which does not exist."
-                )
-
-        rid = RecipientId(str(recipient_id))
-
-        if name is None:
-            if profile_joined_name:
-                name = profile_joined_name
-            elif phone:
-                name = phone
-            else:
-                name = ""
-
-        if color is None:
-            color = get_random_color()
-
-        rid_to_recipient[str(recipient_id)] = Recipient(
-            rid, name=name, color=color, isgroup=isgroup, phone=phone
-        )
-        if phone:
-            phone_to_rid[phone] = str(recipient_id)
-
-
-def make_addressbook(
-    db, version, groups_by_id, rid_to_recipient, phone_to_rid
-):
-    if version == "23":
-        make_addressbook_v23(db, version, groups_by_id, rid_to_recipient)
-    elif version in ["65", "80", "89"]:
-        make_addressbook_v80(
-            db, version, groups_by_id, rid_to_recipient, phone_to_rid
-        )
-    else:
-        # Try latest version
-        make_addressbook_v80(
-            db, version, groups_by_id, rid_to_recipient, phone_to_rid
-        )
-
-
 def get_color(db, recipient_id):
     """ Extract recipient color from the database """
     query = db.execute(
@@ -163,89 +59,7 @@ def get_color(db, recipient_id):
     return color
 
 
-def make_recipient_v23(db, recipient_id):
-    """ Create a Recipient instance from a given recipient id (db version 23)"""
-    if recipient_id.startswith("__textsecure_group__"):
-        qry = db.execute(
-            "SELECT title FROM groups WHERE group_id=?", (recipient_id,)
-        )
-        label = qry.fetchone()
-        isgroup = True
-    else:
-        qry = db.execute(
-            "SELECT system_display_name "
-            "FROM recipient_preferences "
-            "WHERE recipient_ids=?",
-            (recipient_id,),
-        )
-        label = qry.fetchone()
-        isgroup = False
-
-    name = str(recipient_id) if label[0] is None else label[0]
-    color = get_color(db, recipient_id)
-
-    phone = str(recipient_id)
-    rid = RecipientId(recipient_id)
-    return Recipient(rid, name=name, color=color, isgroup=isgroup, phone=phone)
-
-
-def make_recipient_v80(db, recipient_id):
-    """Create a Recipient instance from a recipient id (db version 65, 80, 89)"""
-    qry = db.execute(
-        "SELECT group_id, "
-        "phone, "
-        "system_display_name, "
-        "profile_joined_name, "
-        "color "
-        "FROM recipient "
-        "WHERE _id=?",
-        (recipient_id,),
-    )
-    group_id, phone, name, joined_name, color = qry.fetchone()
-    if color is None:
-        color = get_random_color()
-
-    isgroup = group_id is not None
-    if isgroup:
-        qry = db.execute(
-            "SELECT title FROM groups WHERE group_id=?", (group_id,)
-        )
-        res = qry.fetchone()
-        if res is not None:
-            name = res[0]
-        else:
-            warnings.warn(
-                f"Group for recipient {recipient_id} is {group_id} which does not exist."
-            )
-
-    if name is None:
-        if joined_name:
-            name = joined_name
-        elif phone:
-            name = phone
-        else:
-            name = ""
-
-    rid = RecipientId(recipient_id)
-    return Recipient(rid, name=name, color=color, isgroup=isgroup, phone=phone)
-
-
-def make_recipient(db, recipient_id, version=None):
-    warnings.warn(
-        f"Call to deprecated function {inspect.stack()[0][3]} from {inspect.stack()[1][3]}."
-    )
-    if version == "23":
-        return make_recipient_v23(db, recipient_id)
-    elif version in ["65", "80", "89"]:
-        return make_recipient_v80(db, recipient_id)
-
-    warnings.warn(
-        f"Untested database version {version}, defaulting to latest known working version."
-    )
-    return make_recipient_v80(db, recipient_id)
-
-
-def get_sms_records(db, thread, recipients, version=None):
+def get_sms_records(db, thread, addressbook, version=None):
     """ Collect all the SMS records for a given thread """
     sms_records = []
     sms_qry = db.execute(
@@ -255,12 +69,12 @@ def get_sms_records(db, thread, recipients, version=None):
     )
     qry_res = sms_qry.fetchall()
     for _id, address, date, date_sent, body, _type in qry_res:
-        sms_auth = recipients.get(address)
+        sms_auth = addressbook.get_recipient_by_address(address)
+        if sms_auth is None:
+            print(f"No author for address {address}")
         sms = SMSMessageRecord(
             _id=_id,
-            addressRecipient=sms_auth
-            if sms_auth
-            else make_recipient(db, address, version=version),
+            addressRecipient=sms_auth,
             recipient=thread.recipient,
             dateSent=date_sent,
             dateReceived=date,
@@ -314,7 +128,7 @@ def add_mms_attachments(db, mms, backup_dir, thread_dir):
 
 
 def get_mms_records(
-    db, thread, recipients, backup_dir, thread_dir, version=None
+    db, thread, addressbook, backup_dir, thread_dir, version=None
 ):
     """ Collect all MMS records for a given thread """
     mms_records = []
@@ -337,7 +151,7 @@ def get_mms_records(
     ) in qry_res:
         quote = None
         if quote_id:
-            quote_auth = recipients.get(quote_author)
+            quote_auth = addressbook.get_recipient_by_address(quote_author)
             if quote_auth is None:
                 # Quote is from someone who isn't a recipient (e.g. a friend
                 # quotes a third person in a group). We'll just create a
@@ -352,12 +166,10 @@ def get_mms_records(
                 )
             quote = Quote(_id=quote_id, author=quote_auth, text=quote_body)
 
-        mms_auth = recipients.get(address)
+        mms_auth = addressbook.get_recipient_by_address(address)
         mms = MMSMessageRecord(
             _id=_id,
-            addressRecipient=mms_auth
-            if mms_auth
-            else make_recipient(db, address, version=version),
+            addressRecipient=mms_auth,
             recipient=thread.recipient,
             dateSent=date,
             dateReceived=date_received,
@@ -376,12 +188,12 @@ def get_mms_records(
 
 
 def populate_thread(
-    db, thread, recipients, backup_dir, thread_dir, version=None
+    db, thread, addressbook, backup_dir, thread_dir, version=None
 ):
     """ Populate a thread with all corresponding messages """
-    sms_records = get_sms_records(db, thread, recipients, version=version)
+    sms_records = get_sms_records(db, thread, addressbook, version=version)
     mms_records = get_mms_records(
-        db, thread, recipients, backup_dir, thread_dir, version=version
+        db, thread, addressbook, backup_dir, thread_dir, version=version
     )
     thread.sms = sms_records
     thread.mms = mms_records
@@ -397,13 +209,14 @@ def process_backup(backup_dir, output_dir):
     db = db_conn.cursor()
 
     # Get and index all contact names
-    groups_by_id = make_group_dict(db, version=db_version)
+    # groups_by_id = make_group_dict(db, version=db_version)
 
-    rid_to_recipient: dict(str, Recipient) = {}
-    phone_to_rid: dict(str, str) = {}
-    make_addressbook(
-        db, db_version, groups_by_id, rid_to_recipient, phone_to_rid
-    )
+    # rid_to_recipient: dict(str, Recipient) = {}
+    # phone_to_rid: dict(str, str) = {}
+    # make_addressbook(
+    #    db, db_version, groups_by_id, rid_to_recipient, phone_to_rid
+    # )
+    addressbook: Addressbook = make_addressbook(db, db_version)
 
     # Start by getting the Threads from the database
     query = db.execute("SELECT _id, recipient_ids FROM thread")
@@ -411,11 +224,14 @@ def process_backup(backup_dir, output_dir):
 
     # Combine the recipient objects and the thread info into Thread objects
     for (_id, recipient_id) in threads:
-        recipient = rid_to_recipient[recipient_id]
+        recipient = addressbook.get_recipient_by_address(recipient_id)
+        if recipient is None:
+            print(f"No recipient with address {recipient_id}")
+
         t = Thread(_id=_id, recipient=recipient)
         thread_dir = os.path.join(output_dir, t.sanename)
         populate_thread(
-            db, t, rid_to_recipient, backup_dir, thread_dir, version=db_version
+            db, t, addressbook, backup_dir, thread_dir, version=db_version
         )
         dump_thread(t, thread_dir)
 

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -63,7 +63,7 @@ def dump_thread(thread, output_dir):
 
     # Create the message color CSS (depends on individuals)
     group_color_css = ""
-    msg_css = ".msg-sender-%i { background: %s; }\n"
+    msg_css = ".msg-sender-%i { /* recipient id: %5s */ background: %s;}\n"
     if is_group:
         group_recipients = set(m.addressRecipient for m in messages)
         sender_idx = {r: k for k, r in enumerate(group_recipients)}
@@ -81,15 +81,25 @@ def dump_thread(thread, output_dir):
                     None,
                 )
                 ar_color = ar.color if color is None else color
-            group_color_css += msg_css % (idx, COLORMAP[ar_color])
+            group_color_css += msg_css % (
+                idx,
+                ar.recipientId._id,
+                COLORMAP[ar_color],
+            )
             colors_used.append(ar.color)
     else:
+        # Retrieve sender info from an incoming message, if any
         firstInbox = next(
             (m for m in messages if is_inbox_type(m._type)), None
         )
-        clr = firstInbox.addressRecipient.color if firstInbox else "teal"
-        clr = "teal" if clr is None else clr
-        group_color_css += msg_css % (0, COLORMAP[clr])
+        if firstInbox:
+            clr = firstInbox.addressRecipient.color
+            clr = "teal" if clr is None else clr
+            group_color_css += msg_css % (
+                0,
+                firstInbox.addressRecipient.recipientId._id,
+                COLORMAP[clr],
+            )
 
     # Create a simplified dict for each message
     prev_date = None

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -83,7 +83,7 @@ def dump_thread(thread, output_dir):
                 ar_color = ar.color if color is None else color
             group_color_css += msg_css % (
                 idx,
-                ar.recipientId._id,
+                ar.rid,
                 COLORMAP[ar_color],
             )
             colors_used.append(ar.color)
@@ -97,7 +97,7 @@ def dump_thread(thread, output_dir):
             clr = "teal" if clr is None else clr
             group_color_css += msg_css % (
                 0,
-                firstInbox.addressRecipient.recipientId._id,
+                firstInbox.addressRecipient.rid,
                 COLORMAP[clr],
             )
 
@@ -135,7 +135,7 @@ def dump_thread(thread, output_dir):
         # Deal with quoted messages
         quote = {}
         if isinstance(msg, MMSMessageRecord) and msg.quote:
-            quote_author_id = msg.quote.author.recipientId._id
+            quote_author_id = msg.quote.author.rid
             quote_author_name = msg.quote.author.name
             if quote_author_id == quote_author_name:
                 name = "You"

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -48,14 +48,14 @@ class Attachment:
 
 @dataclass
 class Recipient:
-    recipientId: RecipientId
+    rid: int
     name: str
     color: str
     isgroup: bool
     phone: str
 
     def __hash__(self):
-        return hash(self.recipientId)
+        return hash(self.rid)
 
 
 @dataclass
@@ -101,7 +101,7 @@ class Thread:
         """
         if self.recipient.phone:
             return self._sanitize(self.recipient.phone)
-        return "#" + self.recipient.recipientId._id
+        return "#" + str(self.recipient.rid)
 
     @property
     def name(self):
@@ -114,7 +114,7 @@ class Thread:
         as filename, and fallback on rid."""
         if self.recipient.name:
             return self._sanitize(self.recipient.name)
-        return "#" + self.recipient.recipientId._id
+        return "#" + str(self.recipient.rid)
 
     def _sanitize(self, text):
         """Sanitize text to use as filename"""


### PR DESCRIPTION
Hi @GjjvdBurg 

The goal of this PR is to build the groups and recipients data by querying the `groups` and `recipient` (or `recipient_preferences`) tables only once. It is likely more efficient than fetching contacts one by one (since we're doing a backup, we'll probably end up looking them all anyway, and multiple times in case of groups).

Having everything in dicts will also help to support more group features (e.g. reactions).

This also solves a problem for contacts in groups that don't have a color: in that case each lookup resulted in a new random color, and each message from that sender in a group thread had a different color (i.e., the set() function could not collapse all instances since a different random color was chosen each time).

In my tests the old functions (left as fallback) are not called anymore, but I'd suggest some testing with older DB versions...