### PR TITLE
Feature/versioninfo

### DIFF
--- a/signal2html/addressbook.py
+++ b/signal2html/addressbook.py
@@ -9,6 +9,7 @@ import logging
 
 from .html_colors import get_random_color
 from .models import Recipient
+from .versioninfo import VersionInfo
 
 
 class Addressbook(metaclass=abc.ABCMeta):
@@ -19,11 +20,10 @@ class Addressbook(metaclass=abc.ABCMeta):
     - `_load_recipients()` to load all recipients
     - `get_recipient_by_address()` to return a specific recipient"""
 
-    def __init__(self, db, version):
+    def __init__(self, db):
         """Initializes the addressbook and load all known recipients."""
         self.logger = logging.getLogger(__name__)
         self.db = db
-        self.version = int(version)
         self.rid_to_recipient: dict[str, Recipient] = {}
         self.phone_to_rid: dict[str, str] = {}
         self.groups: dict[int, str] = {}
@@ -268,10 +268,10 @@ class AddressbookV2(Addressbook):
             self._add_recipient(recipient_id, name, color, isgroup, phone)
 
 
-def make_addressbook(db, version) -> Addressbook:
+def make_addressbook(db, versioninfo) -> Addressbook:
     """Factory function for Addressbook.
 
-    The returned implementation depends on the version of the Signal database."""
-    if int(version) <= 23:
-        return AddressbookV1(db, version)
-    return AddressbookV2(db, version)
+    The returned implementation depends on the structure of the Signal database."""
+    if versioninfo.is_addressbook_using_rids():
+        return AddressbookV2(db)
+    return AddressbookV1(db)

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -8,8 +8,8 @@ Copyright: 2020, G.J.J. van den Burg
 
 """
 
+import logging
 import os
-import warnings
 import sqlite3
 import shutil
 
@@ -27,6 +27,8 @@ from .models import Thread
 
 from .html import dump_thread
 
+logger = logging.getLogger(__name__)
+
 
 def check_backup(backup_dir):
     """Check that we have the necessary files"""
@@ -41,9 +43,7 @@ def check_backup(backup_dir):
     # not that. Testing and pull requests welcome.
     version = version_str.split(":")[-1].strip()
     if not version in ["18", "23", "65", "80", "89"]:
-        warnings.warn(
-            f"Warning: Found untested Signal database version: {version}."
-        )
+        logger.warn(f"Found untested Signal database version: {version}.")
     return version
 
 
@@ -87,8 +87,8 @@ def get_attachment_filename(_id, unique_id, backup_dir, thread_dir):
     fname = f"Attachment_{_id}_{unique_id}.bin"
     source = os.path.abspath(os.path.join(backup_dir, fname))
     if not os.path.exists(source):
-        warnings.warn(
-            f"Warning: couldn't find attachment {source}. Maybe it was deleted?"
+        logger.warn(
+            f"Couldn't find attachment '{source}'. Maybe it was deleted or never downloaded."
         )
         return None
 

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -22,7 +22,6 @@ from .models import Attachment
 from .models import MMSMessageRecord
 from .models import Quote
 from .models import Recipient
-from .models import RecipientId
 from .models import SMSMessageRecord
 from .models import Thread
 
@@ -149,18 +148,6 @@ def get_mms_records(
         quote = None
         if quote_id:
             quote_auth = addressbook.get_recipient_by_address(quote_author)
-            if quote_auth is None:
-                # Quote is from someone who isn't a recipient (e.g. a friend
-                # quotes a third person in a group). We'll just create a
-                # recipient object for this person.
-                rid = RecipientId(quote_author)
-                quote_auth = Recipient(
-                    rid,
-                    quote_author,
-                    color=None,
-                    isgroup=False,
-                    phone=str(quote_author),
-                )
             quote = Quote(_id=quote_id, author=quote_auth, text=quote_body)
 
         mms_auth = addressbook.get_recipient_by_address(address)

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -59,7 +59,7 @@ def get_color(db, recipient_id):
     return color
 
 
-def get_sms_records(db, thread, addressbook, versioninfo=None):
+def get_sms_records(db, thread, addressbook):
     """ Collect all the SMS records for a given thread """
     sms_records = []
     sms_qry = db.execute(
@@ -177,9 +177,7 @@ def populate_thread(
     db, thread, addressbook, backup_dir, thread_dir, versioninfo=None
 ):
     """ Populate a thread with all corresponding messages """
-    sms_records = get_sms_records(
-        db, thread, addressbook, versioninfo=versioninfo
-    )
+    sms_records = get_sms_records(db, thread, addressbook)
     mms_records = get_mms_records(
         db,
         thread,

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -21,17 +21,21 @@ from unicodedata import normalize
 
 
 @dataclass
-class RecipientId:
-    _id: str  # phone number (?)
+class Recipient:
+    rid: int
+    name: str
+    color: str
+    isgroup: bool
+    phone: str
 
     def __hash__(self):
-        return hash(self._id)
+        return hash(self.rid)
 
 
 @dataclass
 class Quote:
     _id: int
-    author: RecipientId
+    author: Recipient
     text: str
 
 
@@ -44,18 +48,6 @@ class Attachment:
     height: int
     quote: bool
     unique_id: str
-
-
-@dataclass
-class Recipient:
-    rid: int
-    name: str
-    color: str
-    isgroup: bool
-    phone: str
-
-    def __hash__(self):
-        return hash(self.rid)
 
 
 @dataclass

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Class grouping version-specific information from the signal database.
+
+License: See LICENSE file.
+"""
+
+
+class VersionInfo(object):
+    def __init__(self, version):
+        self.version = int(version)
+
+    def is_tested_version(self) -> bool:
+        """Returns whether the database version has been tested.
+
+        Testing and pull requests welcome."""
+        return self.version in [18, 23, 65, 80, 89]
+
+    def is_addressbook_using_rids(self) -> bool:
+        """Returns whether the contacts are structured using recipient IDs.
+
+        Previous versions referred to contacts using their phone numbers or a
+        special group ID. Current knowledge: change happened strictly after
+        version 23 and at the latest at version 65."""
+
+        return self.version > 23


### PR DESCRIPTION
Hi @GjjvdBurg 

This small PR is about some left-over changes:

- Removes `RecipientId` class which was no longer in use (incorrectly referenced in the `Quote` class).
- Change the last uses of `warnings` and replace with `logging`.

And more importantly, centralize the tests where the database version is relevant into a dedicated class (`VersionInfo`).