### PR TITLE
Feature/reactions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,12 @@ REQUIRES_PYTHON = ">=3.6.0"
 VERSION = None
 
 # What packages are required for this module to be executed?
-REQUIRED = ["emoji", "jinja2", 'dataclasses;python_version=="3.6"']
+REQUIRED = [
+    "emoji",
+    "jinja2",
+    'dataclasses;python_version=="3.6"',
+    "pure-protobuf",
+]
 
 # What packages are optional?
 EXTRAS = {}

--- a/signal2html/addressbook.py
+++ b/signal2html/addressbook.py
@@ -9,6 +9,7 @@ import logging
 
 from .html_colors import get_random_color
 from .models import Recipient
+from .versioninfo import VersionInfo
 
 
 class Addressbook(metaclass=abc.ABCMeta):
@@ -19,11 +20,10 @@ class Addressbook(metaclass=abc.ABCMeta):
     - `_load_recipients()` to load all recipients
     - `get_recipient_by_address()` to return a specific recipient"""
 
-    def __init__(self, db, version):
+    def __init__(self, db):
         """Initializes the addressbook and load all known recipients."""
         self.logger = logging.getLogger(__name__)
         self.db = db
-        self.version = int(version)
         self.rid_to_recipient: dict[str, Recipient] = {}
         self.phone_to_rid: dict[str, str] = {}
         self.groups: dict[int, str] = {}
@@ -268,10 +268,10 @@ class AddressbookV2(Addressbook):
             self._add_recipient(recipient_id, name, color, isgroup, phone)
 
 
-def make_addressbook(db, version) -> Addressbook:
+def make_addressbook(db, versioninfo) -> Addressbook:
     """Factory function for Addressbook.
 
-    The returned implementation depends on the version of the Signal database."""
-    if int(version) <= 23:
-        return AddressbookV1(db, version)
-    return AddressbookV2(db, version)
+    The returned implementation depends on the structure of the Signal database."""
+    if versioninfo.is_addressbook_using_rids():
+        return AddressbookV2(db)
+    return AddressbookV1(db)

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -8,8 +8,8 @@ Copyright: 2020, G.J.J. van den Burg
 
 """
 
+import logging
 import os
-import warnings
 import sqlite3
 import shutil
 
@@ -27,6 +27,8 @@ from .models import Thread
 
 from .html import dump_thread
 
+logger = logging.getLogger(__name__)
+
 
 def check_backup(backup_dir):
     """Check that we have the necessary files"""
@@ -41,9 +43,7 @@ def check_backup(backup_dir):
     # not that. Testing and pull requests welcome.
     version = version_str.split(":")[-1].strip()
     if not version in ["18", "23", "65", "80", "89"]:
-        warnings.warn(
-            f"Warning: Found untested Signal database version: {version}."
-        )
+        logger.warn(f"Found untested Signal database version: {version}.")
     return version
 
 
@@ -87,8 +87,8 @@ def get_attachment_filename(_id, unique_id, backup_dir, thread_dir):
     fname = f"Attachment_{_id}_{unique_id}.bin"
     source = os.path.abspath(os.path.join(backup_dir, fname))
     if not os.path.exists(source):
-        warnings.warn(
-            f"Warning: couldn't find attachment {source}. Maybe it was deleted?"
+        logger.warn(
+            f"Couldn't find attachment '{source}'. Maybe it was deleted or never downloaded."
         )
         return None
 

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -12,6 +12,10 @@ import logging
 import os
 import sqlite3
 import shutil
+import datetime as dt
+
+from .dbproto import StructuredReaction
+from .dbproto import StructuredReactions
 
 from .addressbook import make_addressbook
 
@@ -21,6 +25,7 @@ from .exceptions import DatabaseVersionNotFound
 from .models import Attachment
 from .models import MMSMessageRecord
 from .models import Quote
+from .models import Reaction
 from .models import Recipient
 from .models import SMSMessageRecord
 from .models import Thread
@@ -125,14 +130,51 @@ def add_mms_attachments(db, mms, backup_dir, thread_dir):
         mms.attachments.append(a)
 
 
+def get_mms_reactions(encoded_reactions, addressbook, mid):
+    reactions = []
+    try:
+        if encoded_reactions:
+            structured_reactions = StructuredReactions.loads(encoded_reactions)
+            for structured_reaction in structured_reactions.reactions:
+                rid = addressbook.get_recipient_by_address(
+                    str(structured_reaction.who)
+                )
+                reaction = Reaction(
+                    rid=rid,
+                    what=structured_reaction.what,
+                    time_sent=dt.datetime.fromtimestamp(
+                        structured_reaction.time_sent // 1000
+                    ),
+                    time_received=dt.datetime.fromtimestamp(
+                        structured_reaction.time_received // 1000
+                    ),
+                )
+                reaction.time_sent = reaction.time_sent.replace(
+                    microsecond=(structured_reaction.time_sent % 1000) * 1000
+                )
+                reaction.time_received = reaction.time_received.replace(
+                    microsecond=(structured_reaction.time_received % 1000)
+                    * 1000
+                )
+                reactions.append(reaction)
+
+        return reactions
+    except Exception as e:
+        logger.warn(f"Failed to load reactions for message {mid}: {str(e)}")
+        return []
+
+
 def get_mms_records(
-    db, thread, addressbook, backup_dir, thread_dir, versioninfo=None
+    db, thread, addressbook, backup_dir, thread_dir, versioninfo
 ):
     """ Collect all MMS records for a given thread """
     mms_records = []
+
+    reaction_expr = versioninfo.get_reactions_query_column()
+
     qry = db.execute(
         "SELECT _id, address, date, date_received, body, quote_id, "
-        "quote_author, quote_body, msg_box FROM mms WHERE thread_id=?",
+        f"quote_author, quote_body, msg_box, {reaction_expr} FROM mms WHERE thread_id=?",
         (thread._id,),
     )
     qry_res = qry.fetchall()
@@ -146,11 +188,11 @@ def get_mms_records(
         quote_author,
         quote_body,
         msg_box,
+        reactions,
     ) in qry_res:
-        quote = None
-        if quote_id:
-            quote_auth = addressbook.get_recipient_by_address(quote_author)
-            quote = Quote(_id=quote_id, author=quote_auth, text=quote_body)
+        quote = get_mms_quote(addressbook, quote_id, quote_author, quote_body)
+
+        decoded_reactions = get_mms_reactions(reactions, addressbook, _id)
 
         mms_auth = addressbook.get_recipient_by_address(address)
         mms = MMSMessageRecord(
@@ -163,6 +205,7 @@ def get_mms_records(
             body=body,
             quote=quote,
             attachments=[],
+            reactions=decoded_reactions,
             _type=msg_box,
         )
         mms_records.append(mms)
@@ -171,6 +214,14 @@ def get_mms_records(
         add_mms_attachments(db, mms, backup_dir, thread_dir)
 
     return mms_records
+
+
+def get_mms_quote(addressbook, quote_id, quote_author, quote_body):
+    quote = None
+    if quote_id:
+        quote_auth = addressbook.get_recipient_by_address(quote_author)
+        quote = Quote(_id=quote_id, author=quote_auth, text=quote_body)
+    return quote
 
 
 def populate_thread(
@@ -186,7 +237,7 @@ def populate_thread(
         addressbook,
         backup_dir,
         thread_dir,
-        versioninfo=versioninfo,
+        versioninfo,
     )
     thread.sms = sms_records
     thread.mms = mms_records
@@ -212,7 +263,7 @@ def process_backup(backup_dir, output_dir):
     for (_id, recipient_id) in threads:
         recipient = addressbook.get_recipient_by_address(recipient_id)
         if recipient is None:
-            print(f"No recipient with address {recipient_id}")
+            logger.warn(f"No recipient with address {recipient_id}")
 
         t = Thread(_id=_id, recipient=recipient)
         thread_dir = os.path.join(output_dir, t.sanename)

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -22,7 +22,6 @@ from .models import Attachment
 from .models import MMSMessageRecord
 from .models import Quote
 from .models import Recipient
-from .models import RecipientId
 from .models import SMSMessageRecord
 from .models import Thread
 
@@ -149,18 +148,6 @@ def get_mms_records(
         quote = None
         if quote_id:
             quote_auth = addressbook.get_recipient_by_address(quote_author)
-            if quote_auth is None:
-                # Quote is from someone who isn't a recipient (e.g. a friend
-                # quotes a third person in a group). We'll just create a
-                # recipient object for this person.
-                rid = RecipientId(quote_author)
-                quote_auth = Recipient(
-                    rid,
-                    quote_author,
-                    color=None,
-                    isgroup=False,
-                    phone=str(quote_author),
-                )
             quote = Quote(_id=quote_id, author=quote_auth, text=quote_body)
 
         mms_auth = addressbook.get_recipient_by_address(address)

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -142,11 +142,11 @@ def get_mms_reactions(encoded_reactions, addressbook, mid):
             return []
 
         for structured_reaction in structured_reactions.reactions:
-            rid = addressbook.get_recipient_by_address(
+            recipient = addressbook.get_recipient_by_address(
                 str(structured_reaction.who)
             )
             reaction = Reaction(
-                rid=rid,
+                recipient=recipient,
                 what=structured_reaction.what,
                 time_sent=dt.datetime.fromtimestamp(
                     structured_reaction.time_sent // 1000

--- a/signal2html/dbproto.py
+++ b/signal2html/dbproto.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Extraction classes for Signal protocol objects.
+
+These classes are used to extract values in the database encoded as protobuf messages.
+
+License: See LICENSE file.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+from pure_protobuf.dataclasses_ import field, message, optional_field
+from pure_protobuf.types import uint64
+
+
+@message
+@dataclass
+class StructuredReaction:
+    what: str = optional_field(1)
+    who: Optional[uint64] = optional_field(2)
+    time_sent: Optional[uint64] = optional_field(3)
+    time_received: Optional[uint64] = optional_field(4)
+
+
+@message
+@dataclass
+class StructuredReactions:
+    reactions: List[StructuredReaction] = field(1, default_factory=list)

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -184,15 +184,27 @@ def dump_thread(thread, output_dir):
             "name": aR.name,
             "sender_idx": sender_idx[aR] if is_group else "0",
             "quote": quote,
+            "reactions": [],
         }
 
-        # Add attachments
+        # Add attachments and reactions
         if isinstance(msg, MMSMessageRecord):
             for a in msg.attachments:
                 if a.quote:
                     out["quote"]["attachments"].append(a)
                 else:
                     out["attachments"].append(a)
+
+            for r in msg.reactions:
+                out["reactions"].append(
+                    {
+                        "name": r.rid.name,
+                        "color": COLORMAP[r.rid.color],
+                        "what": r.what,
+                        "time_sent": r.time_sent,
+                        "time_received": r.time_received,
+                    }
+                )
 
         simple_messages.append(out)
 

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -198,8 +198,8 @@ def dump_thread(thread, output_dir):
             for r in msg.reactions:
                 out["reactions"].append(
                     {
-                        "name": r.rid.name,
-                        "color": COLORMAP[r.rid.color],
+                        "recipient_id": r.recipient.rid,
+                        "name": r.recipient.name,
                         "what": r.what,
                         "time_sent": r.time_sent,
                         "time_received": r.time_received,

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -21,17 +21,21 @@ from unicodedata import normalize
 
 
 @dataclass
-class RecipientId:
-    _id: str  # phone number (?)
+class Recipient:
+    rid: int
+    name: str
+    color: str
+    isgroup: bool
+    phone: str
 
     def __hash__(self):
-        return hash(self._id)
+        return hash(self.rid)
 
 
 @dataclass
 class Quote:
     _id: int
-    author: RecipientId
+    author: Recipient
     text: str
 
 
@@ -44,18 +48,6 @@ class Attachment:
     height: int
     quote: bool
     unique_id: str
-
-
-@dataclass
-class Recipient:
-    rid: int
-    name: str
-    color: str
-    isgroup: bool
-    phone: str
-
-    def __hash__(self):
-        return hash(self.rid)
 
 
 @dataclass

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import List
 from re import sub
 from unicodedata import normalize
+from datetime import datetime
 
 
 @dataclass
@@ -67,9 +68,18 @@ class MessageRecord(DisplayRecord):
 
 
 @dataclass
+class Reaction:
+    rid: Recipient
+    what: str
+    time_sent: datetime
+    time_received: datetime
+
+
+@dataclass
 class MMSMessageRecord(MessageRecord):
     quote: Quote
     attachments: List[Attachment]
+    reactions: List[Reaction]
 
 
 @dataclass

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -69,7 +69,7 @@ class MessageRecord(DisplayRecord):
 
 @dataclass
 class Reaction:
-    rid: Recipient
+    recipient: Recipient
     what: str
     time_sent: datetime
     time_received: datetime

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -139,6 +139,65 @@
         position: relative;
       }
 
+      .msg-reactions {
+        margin-top: 5px;
+        text-align: right;
+      }
+
+      .msg-reaction {
+        padding-left: 8px;
+        padding-right: 8px;
+        background-color: #cccccc;
+        border-radius: 1em;
+        border: 1px solid white;
+        line-height: 150%;
+      }
+
+      .msg-reaction-self {
+        background-color: #aaaaaa;
+      }
+
+      .msg-reaction {
+        position: relative;
+      }
+
+      .msg-reaction .msg-reaction-info {
+        display: block;
+        position: absolute;
+        z-index: 1;
+        visibility: hidden;
+        width: 200px;
+        background-color: #505050;
+        color: white;
+        font-weight: bold;
+        text-align: center;
+        padding: 5px 0;
+        border-radius: 3px;
+        margin-left: -100px;
+        bottom: 125%;
+        left: 50%;
+
+        opacity: 0;
+        transition: opacity 0.2s;
+      }
+
+      /* Draw an arrow using border styles */
+      .msg-reaction .msg-reaction-info::before {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        margin-left: -5px;
+        border-width: 5px;
+        border-style: solid;
+        border-color: #505050 transparent transparent transparent;
+      }
+
+      .msg-reaction:hover .msg-reaction-info {
+        visibility: visible;
+        opacity: 1;
+      }
+          
       .msg-quote {
         display: flex;
         width: 98%;
@@ -252,6 +311,13 @@
           </div>
          {% endif %}
          <span class="msg-date">{{ msg.date.strftime('%b %d, %H:%M') }}</span>
+         {% if msg.reactions %}
+         <div class="msg-reactions">
+          {% for reaction in msg.reactions %}
+          <span class="msg-reaction"><span class="msg-emoji"><!-- From: {{reaction.recipient_id}} -->{{reaction.what}}<span style="color: {{reaction.color}};" class="msg-reaction-info">From {{reaction.name}} <br>Sent {{reaction.time_sent.strftime('%b %d, %H:%M')}}<br>Received {{reaction.time_received.strftime('%b %d, %H:%M')}}</span></span></span>
+          {% endfor %}
+         </div>
+         {% endif %}
        </div>
       {% endif %}
       {% endfor %}

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -169,9 +169,11 @@
         width: 200px;
         background-color: #505050;
         color: white;
-        font-weight: bold;
         text-align: center;
         padding: 5px 0;
+        border-color: white;
+        border-width: 1px;
+        border-style: solid;
         border-radius: 3px;
         margin-left: -100px;
         bottom: 125%;
@@ -190,7 +192,7 @@
         margin-left: -5px;
         border-width: 5px;
         border-style: solid;
-        border-color: #505050 transparent transparent transparent;
+        border-color: white transparent transparent transparent;
       }
 
       .msg-reaction:hover .msg-reaction-info {
@@ -314,7 +316,7 @@
          {% if msg.reactions %}
          <div class="msg-reactions">
           {% for reaction in msg.reactions %}
-          <span class="msg-reaction"><span class="msg-emoji"><!-- From: {{reaction.recipient_id}} -->{{reaction.what}}<span style="color: {{reaction.color}};" class="msg-reaction-info">From {{reaction.name}} <br>Sent {{reaction.time_sent.strftime('%b %d, %H:%M')}}<br>Received {{reaction.time_received.strftime('%b %d, %H:%M')}}</span></span></span>
+          <span class="msg-reaction"><span class="msg-emoji"><!-- From: {{reaction.recipient_id}} -->{{reaction.what}}</span><span class="msg-reaction-info">From {{reaction.name}} <br>Sent {{reaction.time_sent.strftime('%b %d, %H:%M')}}<br>Received {{reaction.time_received.strftime('%b %d, %H:%M')}}</span></span>
           {% endfor %}
          </div>
          {% endif %}

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Class grouping version-specific information from the signal database.
+
+License: See LICENSE file.
+"""
+
+
+class VersionInfo(object):
+    def __init__(self, version):
+        self.version = int(version)
+
+    def is_tested_version(self) -> bool:
+        """Returns whether the database version has been tested.
+
+        Testing and pull requests welcome."""
+        return self.version in [18, 23, 65, 80, 89]
+
+    def is_addressbook_using_rids(self) -> bool:
+        """Returns whether the contacts are structured using recipient IDs.
+
+        Previous versions referred to contacts using their phone numbers or a
+        special group ID. Current knowledge: change happened strictly after
+        version 23 and at the latest at version 65."""
+
+        return self.version > 23

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -15,6 +15,7 @@ class VersionInfo(object):
         """Returns whether the database version has been tested.
 
         Testing and pull requests welcome."""
+
         return self.version in [18, 23, 65, 80, 89]
 
     def is_addressbook_using_rids(self) -> bool:
@@ -25,3 +26,8 @@ class VersionInfo(object):
         version 23 and at the latest at version 65."""
 
         return self.version > 23
+
+    def get_reactions_query_column(self) -> str:
+        """Returns a SQL expression to retrieve reactions to MMS messages."""
+
+        return "reactions" if self.version >= 89 else "''"

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -22,12 +22,11 @@ class VersionInfo(object):
         """Returns whether the contacts are structured using recipient IDs.
 
         Previous versions referred to contacts using their phone numbers or a
-        special group ID. Current knowledge: change happened strictly after
-        version 23 and at the latest at version 65."""
+        special group ID."""
 
-        return self.version > 23
+        return self.version >= 24
 
     def get_reactions_query_column(self) -> str:
         """Returns a SQL expression to retrieve reactions to MMS messages."""
 
-        return "reactions" if self.version >= 89 else "''"
+        return "reactions" if self.version >= 37 else "''"


### PR DESCRIPTION
This PR builds over #18 so that one should be merged first.

This PR adds a new dependency on pure-protobuf which is used to decode protobuf messages kept within the database. In this case, MMS entries have a 'reactions' column encoding the reactions that were received to that message.

The reactions are printed individually (in contrast to the signal app, which regroups similar reactions together). A "tooltip" is displayed whenever the cursor hovers over one, printing out additional details. (In addition to grouping like reactions, an additional improvement would be to have a print-specific layout for the details).
