### PR TITLE
Feature/mentions

### DIFF
--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -280,7 +280,7 @@ def get_mentions(db, addressbook, thread_id, versioninfo):
     """Retrieve all mentions in the DB for the requested thread into a dictionary."""
     mentions = {}
 
-    if versioninfo.are_mentions_supported:
+    if versioninfo.are_mentions_supported():
         query = db.execute(
             "SELECT _id, message_id, recipient_id, range_start, range_length "
             "FROM mention WHERE thread_id=?",

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -12,6 +12,7 @@ import sqlite3
 import shutil
 import datetime as dt
 
+from .dbproto import StructuredMentions
 from .dbproto import StructuredReaction
 from .dbproto import StructuredReactions
 
@@ -129,7 +130,38 @@ def add_mms_attachments(db, mms, backup_dir, thread_dir):
         mms.attachments.append(a)
 
 
+def get_mms_mentions(encoded_mentions, addressbook, mid):
+    """Decode mentions encoded in a SQL blob."""
+    mentions = {}
+    if encoded_mentions:
+        try:
+            structured_mentions = StructuredMentions.loads(encoded_mentions)
+        except (ValueError, IndexError, TypeError) as e:
+            logger.warn(
+                f"Failed to load quote mentions for message {mid}: {str(e)}"
+            )
+            return []
+
+        for structured_mention in structured_mentions.mentions:
+            recipient = addressbook.get_recipient_by_uuid(
+                structured_mention.who_uuid
+            )
+            name = recipient.name
+            mention = Mention(
+                mention_id=-1, name=name, length=structured_mention.length
+            )
+            range_start = (
+                0
+                if structured_mention.start is None
+                else structured_mention.start
+            )
+            mentions[range_start] = mention
+
+    return mentions
+
+
 def get_mms_reactions(encoded_reactions, addressbook, mid):
+    """Decode reactions encoded in a SQL blob."""
     reactions = []
     if encoded_reactions:
         try:
@@ -173,9 +205,11 @@ def get_mms_records(
 
     reaction_expr = versioninfo.get_reactions_query_column()
 
+    quote_mentions_expr = versioninfo.get_quote_mentions_query_column()
+
     qry = db.execute(
         "SELECT _id, address, date, date_received, body, quote_id, "
-        f"quote_author, quote_body, msg_box, {reaction_expr} FROM mms WHERE thread_id=?",
+        f"quote_author, quote_body, {quote_mentions_expr}, msg_box, {reaction_expr} FROM mms WHERE thread_id=?",
         (thread._id,),
     )
     qry_res = qry.fetchall()
@@ -188,10 +222,18 @@ def get_mms_records(
         quote_id,
         quote_author,
         quote_body,
+        quote_mentions,
         msg_box,
         reactions,
     ) in qry_res:
-        quote = get_mms_quote(addressbook, quote_id, quote_author, quote_body)
+        quote = get_mms_quote(
+            addressbook,
+            quote_id,
+            quote_author,
+            quote_body,
+            quote_mentions,
+            _id,
+        )
 
         decoded_reactions = get_mms_reactions(reactions, addressbook, _id)
 
@@ -217,15 +259,25 @@ def get_mms_records(
     return mms_records
 
 
-def get_mms_quote(addressbook, quote_id, quote_author, quote_body):
+def get_mms_quote(
+    addressbook, quote_id, quote_author, quote_body, quote_mentions, mid
+):
+    """Retrieve quote (replied message) from a MMS message."""
     quote = None
     if quote_id:
         quote_auth = addressbook.get_recipient_by_address(quote_author)
-        quote = Quote(_id=quote_id, author=quote_auth, text=quote_body)
+        decoded_mentions = get_mms_mentions(quote_mentions, addressbook, mid)
+        quote = Quote(
+            _id=quote_id,
+            author=quote_auth,
+            text=quote_body,
+            mentions=decoded_mentions,
+        )
     return quote
 
 
 def get_mentions(db, addressbook, thread_id, versioninfo):
+    """Retrieve all mentions in the DB for the requested thread into a dictionary."""
     mentions = {}
 
     if versioninfo.are_mentions_supported:

--- a/signal2html/dbproto.py
+++ b/signal2html/dbproto.py
@@ -11,7 +11,7 @@ License: See LICENSE file.
 from dataclasses import dataclass
 from typing import List, Optional
 from pure_protobuf.dataclasses_ import field, message, optional_field
-from pure_protobuf.types import uint64
+from pure_protobuf.types import uint32, uint64
 
 
 @message
@@ -27,3 +27,17 @@ class StructuredReaction:
 @dataclass
 class StructuredReactions:
     reactions: List[StructuredReaction] = field(1, default_factory=list)
+
+
+@message
+@dataclass
+class StructuredMention:
+    start: uint32 = optional_field(1)
+    length: uint32 = optional_field(2)
+    who_uuid: str = optional_field(3)
+
+
+@message
+@dataclass
+class StructuredMentions:
+    mentions: List[StructuredMention] = field(1, default_factory=list)

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -57,7 +57,8 @@ def format_message(body, mentions={}):
             mention = mentions.get(i)
             if mention:
                 new_body += (
-                    "<span class='msg-mention'>@%s</span>" % mention.name
+                    "<span class='msg-mention'>@%s</span>"
+                    % format_message(mention.name)
                 )
                 skip = (
                     mention.length - 1

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -167,7 +167,7 @@ def dump_thread(thread, output_dir):
                 name = quote_author_name
             quote = {
                 "name": name,
-                "body": format_message(msg.quote.text),
+                "body": format_message(msg.quote.text, msg.quote.mentions),
                 "attachments": [],
             }
 

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -30,7 +30,7 @@ def is_all_emoji(body):
     return len(emoji_list(body)) == len(body) and len(body) > 0
 
 
-def format_message(body, is_quote=False):
+def format_message(body, mentions={}):
     """Format message by processing all characters.
 
     - Wrap emoji in <span> for styling them
@@ -53,6 +53,17 @@ def format_message(body, is_quote=False):
             new_body += "&lt;"
         elif c == ">":
             new_body += "&gt;"
+        elif c == "\ufffc":  # Object replacement character
+            mention = mentions.get(i)
+            if mention:
+                new_body += (
+                    "<span class='msg-mention'>@%s</span>" % mention.name
+                )
+                skip = (
+                    mention.length - 1
+                )  # Not clear in what case this is not 1
+            else:
+                new_body += c
         else:
             new_body += c
     return new_body
@@ -166,7 +177,7 @@ def dump_thread(thread, output_dir):
             all_emoji = not msg.quote and is_all_emoji(body)
         else:
             all_emoji = is_all_emoji(body)
-        body = format_message(body)
+        body = format_message(body, thread.mentions.get(msg._id))
 
         # Create message dictionary
         aR = msg.addressRecipient

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -25,6 +25,7 @@ class Recipient:
     color: str
     isgroup: bool
     phone: str
+    uuid: str
 
     def __hash__(self):
         return hash(self.rid)

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -12,7 +12,7 @@ License: See LICENSE file.
 
 from abc import ABCMeta
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Dict
 from re import sub
 from unicodedata import normalize
 from datetime import datetime
@@ -65,6 +65,13 @@ class MessageRecord(DisplayRecord):
 
 
 @dataclass
+class Mention:
+    mention_id: int
+    name: str
+    length: int
+
+
+@dataclass
 class Reaction:
     recipient: Recipient
     what: str
@@ -90,6 +97,7 @@ class Thread:
     recipient: Recipient
     mms: List[MMSMessageRecord] = field(default_factory=lambda: [])
     sms: List[SMSMessageRecord] = field(default_factory=lambda: [])
+    mentions: Dict[int, Dict[int, Mention]] = field(default_factory=lambda: {})
 
     @property
     def sanephone(self):

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -32,10 +32,18 @@ class Recipient:
 
 
 @dataclass
+class Mention:
+    mention_id: int
+    name: str
+    length: int
+
+
+@dataclass
 class Quote:
     _id: int
     author: Recipient
     text: str
+    mentions: Dict[int, Mention] = field(default_factory=lambda: {})
 
 
 @dataclass
@@ -63,13 +71,6 @@ class DisplayRecord(metaclass=ABCMeta):
 @dataclass
 class MessageRecord(DisplayRecord):
     _id: int
-
-
-@dataclass
-class Mention:
-    mention_id: int
-    name: str
-    length: int
 
 
 @dataclass

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -85,6 +85,10 @@
         font-size: xx-large;
       }
 
+      .msg-mention {
+        background-color: #00000060;
+      }
+
       .msg-date-change {
         font-size: x-small;
         opacity: 50%;

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -5,11 +5,15 @@
 
 License: See LICENSE file.
 """
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class VersionInfo(object):
     def __init__(self, version):
         self.version = int(version)
+        logger.info(f"Using database version {version}.")
 
     def is_tested_version(self) -> bool:
         """Returns whether the database version has been tested.

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -35,3 +35,8 @@ class VersionInfo(object):
         """Returns whether the mentions table is present."""
 
         return self.version >= 68
+
+    def get_quote_mentions_query_column(self) -> str:
+        """Returns a SQL expression to retrieve quote mentions in MMS messages."""
+
+        return "quote_mentions" if self.are_mentions_supported() else "''"

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -30,3 +30,8 @@ class VersionInfo(object):
         """Returns a SQL expression to retrieve reactions to MMS messages."""
 
         return "reactions" if self.version >= 37 else "''"
+
+    def are_mentions_supported(self) -> bool:
+        """Returns whether the mentions table is present."""
+
+        return self.version >= 68


### PR DESCRIPTION
This PR adds support for mentions (@ xxx) in group threads.

Mentions are signified in the message body using the unicode object replacement character (fffc).

Mentions in the main bodies can be retrieved by looking up the `mention` database table, which lists the particular recipients for the mentions at a given position in the messages. For efficiency, the database table is read once when processing each thread.

Mentions in quoted bodies can be retrieved by parsing binary mentions data in the `quote_mentions` field of the message. The recipient is given by UUID. Therefore, code has been added to the addressbook class to allow retrieval of the recipients by their UUID.