### PR TITLE
Feature/group messages

### DIFF
--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -77,6 +77,7 @@ def get_sms_records(db, thread, addressbook):
         sms_auth = addressbook.get_recipient_by_address(address)
         sms = SMSMessageRecord(
             _id=_id,
+            data=None,
             addressRecipient=sms_auth,
             recipient=thread.recipient,
             dateSent=date_sent,
@@ -240,6 +241,7 @@ def get_mms_records(
         mms_auth = addressbook.get_recipient_by_address(address)
         mms = MMSMessageRecord(
             _id=_id,
+            data=None,
             addressRecipient=mms_auth,
             recipient=thread.recipient,
             dateSent=date,

--- a/signal2html/dbproto.py
+++ b/signal2html/dbproto.py
@@ -9,6 +9,7 @@ License: See LICENSE file.
 """
 
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import List, Optional
 from pure_protobuf.dataclasses_ import field, message, optional_field
 from pure_protobuf.types import uint32, uint64
@@ -41,3 +42,70 @@ class StructuredMention:
 @dataclass
 class StructuredMentions:
     mentions: List[StructuredMention] = field(1, default_factory=list)
+
+
+@message
+@dataclass
+class StructuredGroupCall:
+    by: str = optional_field(2)
+    when: uint64 = optional_field(3)
+
+
+@message
+@dataclass
+class StructuredGroupMember:
+    uuid: str = optional_field(1)
+    phone: str = optional_field(2)
+
+
+@message
+@dataclass
+class StructuredGroupDataV1:
+    group_name: str = optional_field(3)
+    phone_members: List[str] = field(4, default_factory=list)
+    members: List[StructuredGroupMember] = field(6, default_factory=list)
+
+
+class StructuredMemberRole(IntEnum):
+    MEMBER_ROLE_UNKNOWN = 0
+    MEMBER_ROLE_DEFAULT = 1
+    MEMBER_ROLE_ADMIN = 2
+
+
+@message
+@dataclass
+class StructuredDecryptedMember:
+    uuid: bytes = field(1)
+    role: StructuredMemberRole = field(2)
+
+
+@message
+@dataclass
+class StructuredDecryptedString:
+    value: str = field(1)
+
+
+@message
+@dataclass
+class StructuredGroupV2Change:
+    by: bytes = optional_field(1)
+    new_members: List[StructuredDecryptedMember] = field(
+        3, default_factory=list
+    )
+    deleted_members: List[bytes] = field(4, default_factory=list)
+    new_title: StructuredDecryptedString = optional_field(10)
+
+
+@message
+@dataclass
+class StructuredGroupV2State:
+    title: str = optional_field(2)
+    rev: uint32 = optional_field(6)
+    members: List[StructuredDecryptedMember] = field(7, default_factory=list)
+
+
+@message
+@dataclass
+class StructuredGroupDataV2:
+    change: StructuredGroupV2Change = field(2)
+    state: StructuredGroupV2State = field(3)

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -58,6 +58,29 @@ class Attachment:
 
 
 @dataclass
+class GroupCallData:
+    initiator: str
+    timestamp: datetime
+
+
+@dataclass
+class MemberInfo:
+    name: str
+    phone: str
+    match_from_phone: bool
+    admin: bool
+
+
+@dataclass
+class GroupUpdateData:
+    group_name: str
+    change_by: MemberInfo
+    members: List[MemberInfo] = field(default_factory=list)
+    new_members: List[MemberInfo] = field(default_factory=list)
+    deleted_members: List[MemberInfo] = field(default_factory=list)
+
+
+@dataclass
 class DisplayRecord(metaclass=ABCMeta):
     addressRecipient: Recipient  # Recipient corresponding to address field
     recipient: Recipient
@@ -71,6 +94,7 @@ class DisplayRecord(metaclass=ABCMeta):
 @dataclass
 class MessageRecord(DisplayRecord):
     _id: int
+    data: any
 
 
 @dataclass

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -236,7 +236,8 @@
         align-self: center;
       }
 
-      .msg-call-incoming .msg-date, .msg-call-outgoing .msg-date, .msg-call-missed .msg-date, .msg-group-update-v1 .msg-group-update-v2 .msg-data {
+      .msg-call-incoming .msg-date, .msg-call-outgoing .msg-date, .msg-call-missed .msg-date,
+      .msg-group-update-v1 .msg-date, .msg-group-update-v2 .msg-date, .msg-group-call .msg-date {
         display: block;
         text-align: center;
       }

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -285,61 +285,107 @@
   </head>
   <body>
     <div class="message-box">
-      {% for msg in messages %}
-      {% if "date_msg" in msg %}
+{% for msg in messages %}
+  {% if "date_msg" in msg %}
       <div id="msg-{{ msg.id }}" class="msg msg-date-change">
-         <p>
-         {{ msg.body }}
-         </p>
-      </div>
-      {% else %}
+        <p>
+      {{ msg.body }}
+        </p>
+  {% else %}
+    {% if msg.type == 'call-incoming' %}
+      <div id="msg-{{ msg.id }}" class="msg msg-{{ msg.type }}">
+        <div class="msg-icon"></div>
+        <div>
+          {{ msg.event_data | safe }} called you
+        </div>
+    {% elif msg.type == 'call-outgoing' %}
+      <div id="msg-{{ msg.id }}" class="msg msg-{{ msg.type }}">
+        <div class="msg-icon"></div>
+        <div>
+          You called
+        </div>
+    {% elif msg.type == 'call-missed' %}
+      <div id="msg-{{ msg.id }}" class="msg msg-{{ msg.type }}">
+        <div class="msg-icon"></div>
+        <div>
+          Missed call
+        </div>
+    {% elif msg.type == 'group-call' %}
+      <div id="msg-{{ msg.id }}" class="msg msg-{{ msg.type }}">
+        <div>
+          Group call {% if msg.event_data %}started by {{ msg.event_data | safe }}{% endif %}
+        </div>
+    {% elif msg.type == 'group-update-v1' or msg.type == 'group-update-v2' %}
+      <div id="msg-{{ msg.id }}" class="msg msg-{{ msg.type }}">
+        <div>
+      {% if msg.event_data.header %}<span>{{msg.event_data.header}}</span>{% endif %}
+          <ul>
+      {% if msg.event_data.name %}<li>Name: {{msg.event_data.name}}{% endif %}
+      {% for member_list in msg.event_data.member_lists %}
+            <li>{{member_list.header}}
+              <ul>
+        {% for member in member_list.members %}
+                <li>{{member | safe}}
+        {% endfor %}
+              </ul>
+      {% endfor %}
+          </ul>
+        </div>
+      {% if msg.attachments %}
+        {% for attach in msg.attachments %}
+        <div>Group photo</div>
+        {{ attachment(attach) }}
+        {% endfor %}
+      {% endif %}
+      {% if debug_messages %}
+        <code>{{msg.body}}</code>
+      {% endif %}
+    {% else %}
       <div id="msg-{{ msg.id }}" class="msg msg-{{ msg.type }} msg-sender-{{ msg.sender_idx }}">
-         {% if msg.isGroup and msg.type == 'incoming' %}
-          <span class="msg-name">{{ msg.name }}</span>
-         {% endif %}
-         {% if msg.quote %}
-          <div class="msg-quote">
-            <div class="msg-quote-message">
-              <span class="msg-name">{{ msg.quote.name }}</span>
-              <pre>{{ msg.quote.body | safe }}</pre>
-            </div>
-            {% if msg.quote.attachments %}
-              <div class="msg-quote-attach">
-              {% for attach in msg.quote.attachments %}
-                {{ attachment(attach) }}
-              {% endfor %}
-              </div>
-            {% endif %}
+      {% if msg.isGroup and msg.type == 'incoming' %}
+        <span class="msg-name">{{ msg.name }}</span>
+      {% endif %}
+      {% if msg.quote %}
+        <div class="msg-quote">
+          <div class="msg-quote-message">
+            <span class="msg-name">{{ msg.quote.name }}</span>
+            <pre>{{ msg.quote.body | safe }}</pre>
           </div>
-         {% endif %}
-         {% if msg.attachments %}
-          {% for attach in msg.attachments %}
+        {% if msg.quote.attachments %}
+          <div class="msg-quote-attach">
+          {% for attach in msg.quote.attachments %}
             {{ attachment(attach) }}
           {% endfor %}
-         {% endif %}
-         {% if msg.isCall %}
-          <div class="msg-icon"></div>
-         {% endif %}
-         {% if msg.body %}
-          {% if msg.isAllEmoji %}
-            <div class="msg-all-emoji">
-          {% else %}
-            <div>
-          {% endif %}
-          <pre>{{ msg.body | safe }}</pre>
           </div>
-         {% endif %}
-         <span class="msg-date">{{ msg.date.strftime('%b %d, %H:%M') }}</span>
-         {% if msg.reactions %}
-         <div class="msg-reactions">
-          {% for reaction in msg.reactions %}
-          <span class="msg-reaction"><span class="msg-emoji"><!-- From: {{reaction.recipient_id}} -->{{reaction.what}}</span><span class="msg-reaction-info">From {{reaction.name}} <br>Sent {{reaction.time_sent.strftime('%b %d, %H:%M')}}<br>Received {{reaction.time_received.strftime('%b %d, %H:%M')}}</span></span>
-          {% endfor %}
-         </div>
-         {% endif %}
-       </div>
+        {% endif %}
+        </div>
       {% endif %}
+      {% if msg.attachments %}
+        {% for attach in msg.attachments %}
+        {{ attachment(attach) }}
+        {% endfor %}
+      {% endif %}
+      {% if msg.body %}
+        {% if msg.isAllEmoji %}
+        <div class="msg-all-emoji">
+        {% else %}
+        <div>
+        {% endif %}
+          <pre>{{ msg.body | safe }}</pre>
+        </div>
+      {% endif %}
+    {% endif %}
+        <span class="msg-date">{{ msg.date.strftime('%b %d, %H:%M') }}</span>
+    {% if msg.reactions %}
+        <div class="msg-reactions">
+      {% for reaction in msg.reactions %}
+          <span class="msg-reaction"><span class="msg-emoji"><!-- From: {{reaction.recipient_id}} -->{{reaction.what}}</span><span class="msg-reaction-info">From {{reaction.name}} <br>Sent {{reaction.time_sent.strftime('%b %d, %H:%M')}}<br>Received {{reaction.time_received.strftime('%b %d, %H:%M')}}</span></span>
       {% endfor %}
+        </div>
+    {% endif %}
+  {% endif %}
+      </div>
+{% endfor %}
     </div>
   </body>
 </html>

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -231,13 +231,26 @@
         max-height: 5em;
       }
 
-      .msg-call-incoming, .msg-call-outgoing, .msg-call-missed {
+      .msg-call-incoming, .msg-call-outgoing, .msg-call-missed, .msg-group-call {
         background: none;
         align-self: center;
       }
-      .msg-call-incoming .msg-date, .msg-call-outgoing .msg-date, .msg-call-missed .msg-date {
+
+      .msg-call-incoming .msg-date, .msg-call-outgoing .msg-date, .msg-call-missed .msg-date, .msg-group-update-v1 .msg-group-update-v2 .msg-data {
         display: block;
         text-align: center;
+      }
+
+      .msg-group-update-v1 {
+        background: none;
+        align-self: center;
+        max-width: 80%;
+      }
+
+      .msg-group-update-v2 {
+        background: none;
+        align-self: center;
+        max-width: 80%;
       }
 
       .msg-icon {

--- a/signal2html/types.py
+++ b/signal2html/types.py
@@ -17,6 +17,11 @@ JOINED_TYPE = 4
 UNSUPPORTED_MESSAGE_TYPE = 5
 INVALID_MESSAGE_TYPE = 6
 
+GROUP_CALL_TYPE = 12
+
+GROUP_CTRL_TYPE_BIT = 0x10000
+GROUP_V2_DATA_TYPE_BIT = 0x80000
+
 BASE_INBOX_TYPE = 20
 BASE_OUTBOX_TYPE = 21
 BASE_SENDING_TYPE = 22
@@ -59,11 +64,28 @@ def is_missed_call(_type):
     return _type == MISSED_CALL_TYPE
 
 
+def is_group_call(_type):
+    return _type == GROUP_CALL_TYPE
+
+
+def is_group_ctrl(_type):
+    return _type & GROUP_CTRL_TYPE_BIT == GROUP_CTRL_TYPE_BIT
+
+
+def is_group_v2_data(_type):
+    return _type & GROUP_V2_DATA_TYPE_BIT == GROUP_V2_DATA_TYPE_BIT
+
+
 def is_joined_type(_type):
     return _type & BASE_TYPE_MASK == JOINED_TYPE
 
 
 def get_named_message_type(_type):
+    if is_group_ctrl(_type):
+        if is_group_v2_data(_type):
+            return "group-update-v2"
+        else:
+            return "group-update-v1"
     if is_outgoing_message_type(_type):
         return "outgoing"
     elif is_inbox_type(_type):
@@ -74,6 +96,8 @@ def get_named_message_type(_type):
         return "call-outgoing"
     elif is_missed_call(_type):
         return "call-missed"
+    elif is_group_call(_type):
+        return "group-call"
     elif is_joined_type(_type):
         return "joined"
     return "unknown"


### PR DESCRIPTION
This PR implements parsing of group events (and fixes #17). Please check #24 first as this is work on top.

The following messages are now parsed. Previously they were rendered as long strings of digits and numbers:
- Group calls
- Group updates (new/deleted members) both for legacy groups and 'new' groups (V2 groups).

https://github.com/GjjvdBurg/signal2html/commit/dddb3bfc6794c27aef80874953f514d06613dfd8 - Identify group event messages by inspecting the type field. Render simple "group call" and "group update" events contents instead of the undecoded body.

https://github.com/GjjvdBurg/signal2html/commit/a1a61c72b97030359602ca45c4240000e975fa51 - Create model classes to store the interesting attributes of group calls and group updates. Decoded data will be into a 'data' member substructure of the MessageRecord class.

https://github.com/GjjvdBurg/signal2html/commit/331d2199276f34f8a93e297a07cd8b6e4c9e335d - Provide decoding classes for the protobuf messages of these events. Only decode fields we end up displaying.

https://github.com/GjjvdBurg/signal2html/commit/2b07cd5544618f29f1179d3b05fda86a0614097b - Code to take the encoded messages and fill our internal data models. In general there are three substeps:
  - The message is encoded as base64, turn that into a binary
  - The binary representation is decoded using the protobuf classes above
  - Finally the data about group (call) members is changed to contacts by using lookup in the addressbook.
    - Legacy groups mainly use telephone numbers as key (sometimes UUIDs). V2 groups (and group calls, a feature of new groups) only use UUIDs.

https://github.com/GjjvdBurg/signal2html/commit/2b07cd5544618f29f1179d3b05fda86a0614097b - Code to make available the model data to the template engine, and render the events. For group updates, the idea is to have a few top level fields and then various list of members (e.g.: new members, deleted members).

Note that 'new' groups (Groups V2) are fairly complex and support member roles, configurable permissions, invite by link, pending members, etc. This PR only decodes new, deleted and current member lists, plus some basic attributes such as the group name. Other changes made to the group are not decoded.