### PR TITLE
Remove msg id for date change messages (fixes #23)

### DIFF
--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -270,7 +270,7 @@
     <div class="message-box">
       {% for msg in messages %}
       {% if "date_msg" in msg %}
-      <div id="msg-{{ msg.id }}" class="msg msg-date-change">
+      <div class="msg msg-date-change">
          <p>
          {{ msg.body }}
          </p>


### PR DESCRIPTION
Realized we can simply remove the ``id`` attribute from these messages, since there is none and it serves no purpose.