### PR TITLE
Feature/display message state

### DIFF
--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -49,6 +49,8 @@ from .types import (
     is_group_v2_data,
 )
 
+from .__version__ import __version__
+
 from .versioninfo import VersionInfo
 
 logger = logging.getLogger(__name__)
@@ -85,18 +87,30 @@ def get_sms_records(db, thread, addressbook):
     """ Collect all the SMS records for a given thread """
     sms_records = []
     sms_qry = db.execute(
-        "SELECT _id, address, date, date_sent, body, type "
+        "SELECT _id, address, date, date_sent, body, type, "
+        "delivery_receipt_count, read_receipt_count "
         "FROM sms WHERE thread_id=?",
         (thread._id,),
     )
     qry_res = sms_qry.fetchall()
-    for _id, address, date, date_sent, body, _type in qry_res:
+    for (
+        _id,
+        address,
+        date,
+        date_sent,
+        body,
+        _type,
+        delivery_receipt_count,
+        read_receipt_count,
+    ) in qry_res:
 
         data = get_data_from_body(_type, body, addressbook, _id)
         sms_auth = addressbook.get_recipient_by_address(address)
         sms = SMSMessageRecord(
             _id=_id,
             data=data,
+            delivery_receipt_count=delivery_receipt_count,
+            read_receipt_count=read_receipt_count,
             addressRecipient=sms_auth,
             recipient=thread.recipient,
             dateSent=date_sent,
@@ -451,10 +465,13 @@ def get_mms_records(
     reaction_expr = versioninfo.get_reactions_query_column()
 
     quote_mentions_expr = versioninfo.get_quote_mentions_query_column()
+    viewed_receipt_count_expr = versioninfo.get_viewed_receipt_count_column()
 
     qry = db.execute(
         "SELECT _id, address, date, date_received, body, quote_id, "
-        f"quote_author, quote_body, {quote_mentions_expr}, msg_box, {reaction_expr} FROM mms WHERE thread_id=?",
+        f"quote_author, quote_body, {quote_mentions_expr}, msg_box, {reaction_expr}, "
+        f"delivery_receipt_count, read_receipt_count, {viewed_receipt_count_expr} "
+        "FROM mms WHERE thread_id=?",
         (thread._id,),
     )
     qry_res = qry.fetchall()
@@ -470,6 +487,9 @@ def get_mms_records(
         quote_mentions,
         msg_box,
         reactions,
+        delivery_receipt_count,
+        read_receipt_count,
+        viewed_receipt_count,
     ) in qry_res:
         quote = get_mms_quote(
             addressbook,
@@ -487,6 +507,8 @@ def get_mms_records(
         mms = MMSMessageRecord(
             _id=_id,
             data=data,
+            delivery_receipt_count=delivery_receipt_count,
+            read_receipt_count=read_receipt_count,
             addressRecipient=mms_auth,
             recipient=thread.recipient,
             dateSent=date,
@@ -497,6 +519,7 @@ def get_mms_records(
             attachments=[],
             reactions=decoded_reactions,
             _type=msg_box,
+            viewed_receipt_count=viewed_receipt_count,
         )
         mms_records.append(mms)
 
@@ -576,6 +599,8 @@ def populate_thread(
 
 def process_backup(backup_dir, output_dir):
     """ Main functionality to convert database into HTML """
+
+    logger.info(f"signal2html version {__version__}")
 
     # Verify backup and open database
     versioninfo = check_backup(backup_dir)

--- a/signal2html/models.py
+++ b/signal2html/models.py
@@ -97,6 +97,8 @@ class DisplayRecord(metaclass=ABCMeta):
 class MessageRecord(DisplayRecord):
     _id: int
     data: any
+    delivery_receipt_count: int
+    read_receipt_count: int
 
 
 @dataclass
@@ -112,6 +114,7 @@ class MMSMessageRecord(MessageRecord):
     quote: Quote
     attachments: List[Attachment]
     reactions: List[Reaction]
+    viewed_receipt_count: int
 
 
 @dataclass

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -34,13 +34,9 @@
   {% elif state == "DISPLAY_TYPE_FAILED" %}
     &#x26a0;{# Warning sign #}
   {% elif state == "DISPLAY_TYPE_DELIVERED" %}
-    &#x2713;&#x2713;{# Double checkmark #}{% if isGroup %}&nbsp;{{deliv_count}}{% endif %}
+    &#x2713;&#x2713;{# Double checkmark #}
   {% elif state == "DISPLAY_TYPE_READ" %}
-    {% if isGroup %}
-      &#x2713;&#x2713;&nbsp;{{deliv_count}}&nbsp;&#x2713;{{read_count}}{# Triple checkmark #}
-    {% else %}
-      NG&#x2713;&#x2713;&#x2713;{# Triple checkmark #}
-    {% endif %}
+    &#x2713;&#x2713;&#x2713;{# Triple checkmark #}
   {% endif%}
 {%- endmacro -%}
 <!DOCTYPE html>

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -34,9 +34,9 @@
   {% elif state == "DISPLAY_TYPE_FAILED" %}
     &#x26a0;{# Warning sign #}
   {% elif state == "DISPLAY_TYPE_DELIVERED" %}
-    &#x2713;&#x2713;{# Double checkmark #}
+    <span class="multiple-checkmarks">&#x2713;&#x2713;</span>{# Double checkmark #}
   {% elif state == "DISPLAY_TYPE_READ" %}
-    &#x2713;&#x2713;&#x2713;{# Triple checkmark #}
+    <span class="multiple-checkmarks">&#x2713;&#x2713;&#x2713;</span>{# Triple checkmark #}
   {% endif%}
 {%- endmacro -%}
 <!DOCTYPE html>
@@ -142,6 +142,12 @@
       audio {
         max-width: 100%;
         width: 400px;
+      }
+
+      .multiple-checkmarks {
+        letter-spacing: -0.3em;
+        margin-left: 3px;
+        margin-right: 3px;
       }
 
       .msg-img-container input[type=checkbox] {

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -22,6 +22,27 @@
     {% endif %}
   </div>
 {%- endmacro %}
+{%- macro message_metadata(date, secure, state, isGroup, deliv_count, read_count) -%}
+  {{ date.strftime(date_time_format) }}
+  {% if not secure %}
+    &#x1f513;&#xfe0e;{# Open lock, text variant #}
+  {%endif%}
+  {% if state == "DISPLAY_TYPE_PENDING" %}
+    &#x25cc;{# Dotted circle #}
+  {% elif state == "DISPLAY_TYPE_SENT" %}
+    &#x2713;{# Checkmark #}
+  {% elif state == "DISPLAY_TYPE_FAILED" %}
+    &#x26a0;{# Warning sign #}
+  {% elif state == "DISPLAY_TYPE_DELIVERED" %}
+    &#x2713;&#x2713;{# Double checkmark #}{% if isGroup %}&nbsp;{{deliv_count}}{% endif %}
+  {% elif state == "DISPLAY_TYPE_READ" %}
+    {% if isGroup %}
+      &#x2713;&#x2713;&nbsp;{{deliv_count}}&nbsp;&#x2713;{{read_count}}{# Triple checkmark #}
+    {% else %}
+      NG&#x2713;&#x2713;&#x2713;{# Triple checkmark #}
+    {% endif %}
+  {% endif%}
+{%- endmacro -%}
 <!DOCTYPE html>
 <meta charset="utf-8">
 <html lang="en">
@@ -71,7 +92,7 @@
         margin-bottom: 5px;
       }
 
-      .msg-date {
+      .msg-data {
         font-size: x-small;
         opacity: 50%;
         display: block;
@@ -238,9 +259,9 @@
         align-self: center;
       }
 
-      .msg-call-incoming .msg-date, .msg-call-outgoing .msg-date, .msg-call-missed .msg-date,
-      .msg-video-call-incoming .msg-date, .msg-video-call-outgoing .msg-date, .msg-video-call-missed .msg-date,
-      .msg-key-update .msg-date, .msg-group-update-v1 .msg-date, .msg-group-update-v2 .msg-date, .msg-group-call .msg-date {
+      .msg-call-incoming .msg-data, .msg-call-outgoing .msg-data, .msg-call-missed .msg-data,
+      .msg-video-call-incoming .msg-data, .msg-video-call-outgoing .msg-data, .msg-video-call-missed .msg-data,
+      .msg-key-update .msg-data, .msg-group-update-v1 .msg-data, .msg-group-update-v2 .msg-data, .msg-group-call .msg-data {
         display: block;
         text-align: center;
       }
@@ -394,11 +415,11 @@
         </div>
       {% endif %}
     {% endif %}
-        <span class="msg-date">{{ msg.date.strftime('%b %d, %H:%M') }}</span>
+        <span class="msg-data">{{ message_metadata(msg.date, msg.secure, msg.send_state, msg.isGroup, msg.delivery_receipt_count, msg.read_receipt_count) }}</span>
     {% if msg.reactions %}
         <div class="msg-reactions">
       {% for reaction in msg.reactions %}
-          <span class="msg-reaction"><span class="msg-emoji"><!-- From: {{reaction.recipient_id}} -->{{reaction.what}}</span><span class="msg-reaction-info">From {{reaction.name}} <br>Sent {{reaction.time_sent.strftime('%b %d, %H:%M')}}<br>Received {{reaction.time_received.strftime('%b %d, %H:%M')}}</span></span>
+          <span class="msg-reaction"><span class="msg-emoji"><!-- From: {{reaction.recipient_id}} -->{{reaction.what}}</span><span class="msg-reaction-info">From {{reaction.name}} <br>Sent {{reaction.time_sent.strftime(date_time_format)}}<br>Received {{reaction.time_received.strftime(date_time_format)}}</span></span>
       {% endfor %}
         </div>
     {% endif %}

--- a/signal2html/types.py
+++ b/signal2html/types.py
@@ -8,6 +8,8 @@ License: See LICENSE file.
 
 """
 
+from enum import Enum
+
 BASE_TYPE_MASK = 0x1F
 
 INCOMING_AUDIO_CALL_TYPE = 1
@@ -26,6 +28,8 @@ KEY_UPDATE_TYPE_BIT = 0x200
 GROUP_CTRL_TYPE_BIT = 0x10000
 GROUP_V2_DATA_TYPE_BIT = 0x80000
 
+SECURE_BIT = 0x800000
+
 BASE_INBOX_TYPE = 20
 BASE_OUTBOX_TYPE = 21
 BASE_SENDING_TYPE = 22
@@ -43,6 +47,46 @@ OUTGOING_MESSAGE_TYPES = [
     BASE_PENDING_SECURE_SMS_FALLBACK,
     BASE_PENDING_INSECURE_SMS_FALLBACK,
 ]
+
+
+class DisplayType(Enum):
+    DISPLAY_TYPE_NONE = 0
+    DISPLAY_TYPE_PENDING = 1
+    DISPLAY_TYPE_SENT = 2
+    DISPLAY_TYPE_FAILED = 3
+    DISPLAY_TYPE_DELIVERED = 4
+    DISPLAY_TYPE_READ = 5
+
+    @classmethod
+    def from_state(
+        cls, _type: int, is_delivered: bool = False, is_read: bool = False
+    ):
+        if not is_outgoing_message_type(_type):
+            return cls.DISPLAY_TYPE_NONE
+
+        if is_read:
+            return cls.DISPLAY_TYPE_READ
+
+        if is_delivered:
+            return cls.DISPLAY_TYPE_DELIVERED
+
+        base_type = _type & BASE_TYPE_MASK
+
+        if base_type == BASE_SENT_FAILED_TYPE:
+            return cls.DISPLAY_TYPE_FAILED
+
+        if base_type == BASE_SENT_TYPE:
+            return cls.DISPLAY_TYPE_SENT
+
+        if (
+            base_type == BASE_OUTBOX_TYPE
+            or base_type == BASE_SENDING_TYPE
+            or base_type == BASE_PENDING_SECURE_SMS_FALLBACK
+            or base_type == BASE_PENDING_INSECURE_SMS_FALLBACK
+        ):
+            return cls.DISPLAY_TYPE_PENDING
+
+        return cls.DISPLAY_TYPE_NONE
 
 
 def is_outgoing_message_type(_type):
@@ -82,6 +126,10 @@ def is_group_call(_type):
 
 def is_key_update(_type):
     return _type & KEY_UPDATE_TYPE_BIT == KEY_UPDATE_TYPE_BIT
+
+
+def is_secure(_type):
+    return _type & SECURE_BIT == SECURE_BIT
 
 
 def is_group_ctrl(_type):

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -49,3 +49,8 @@ class VersionInfo(object):
         """Returns a SQL expression to retrieve quote mentions in MMS messages."""
 
         return "quote_mentions" if self.are_mentions_supported() else "''"
+
+    def get_viewed_receipt_count_column(self) -> str:
+        """Returns a SQL expression to retrieve the viewed receipt count of attachments of MMS messages."""
+
+        return "viewed_receipt_count" if self.version >= 83 else "'0'"


### PR DESCRIPTION
This PR adds more information to each message:
- Whether the message was 'secure' or not (in which cas an open padlock is shown)
- Whether the message was sent (one checkmark), delivered (two) or read (three)
- For group messages, how many delivery and how many read receipts

I also added code to display failed messages and in-progress messages but I've not seen them in any backup.

This PR is over the bugfix/rid_not_found branch so that should be committed first. I think with this code, we're now showing messages as meaningfully as the native client.

In addition, the version is now logged on startup to help troubleshooting.
