### PR TITLE
Remove empty messages

### DIFF
--- a/signal2html/addressbook.py
+++ b/signal2html/addressbook.py
@@ -230,11 +230,9 @@ class AddressbookV2(Addressbook):
             self.logger.warn(
                 f"Recipient with rid {address} not in addressbook, adding it."
             )
-            return self._add_recipient(
-                rid, "", "", get_random_color(), False, ""
-            )
-        else:
-            return recipient
+            color = get_random_color()
+            return self._add_recipient(rid, "", "", color, False, "")
+        return recipient
 
     def _isgroup(self, group_id) -> bool:
         """Decides whether a group_id refers to a group."""

--- a/signal2html/addressbook.py
+++ b/signal2html/addressbook.py
@@ -10,9 +10,9 @@ import abc
 import logging
 
 from typing import Union
+
 from .html_colors import get_random_color
 from .models import Recipient
-from .versioninfo import VersionInfo
 
 
 class Addressbook(metaclass=abc.ABCMeta):

--- a/signal2html/addressbook.py
+++ b/signal2html/addressbook.py
@@ -9,6 +9,7 @@ License: See LICENSE file.
 import abc
 import logging
 
+from typing import Union
 from .html_colors import get_random_color
 from .models import Recipient
 from .versioninfo import VersionInfo
@@ -217,11 +218,11 @@ class AddressbookV1(Addressbook):
 
 
 class AddressbookV2(Addressbook):
-    def get_recipient_by_address(self, address: str) -> Recipient:
+    def get_recipient_by_address(self, address: Union[int, str]) -> Recipient:
         """In this database version, all addresses are recipient_id's and
         creating them here is not expected to happen."""
 
-        rid = address
+        rid = str(address)
         recipient = self.rid_to_recipient.get(rid)
 
         if recipient is None:

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -15,7 +15,6 @@ import base64
 import binascii
 import uuid
 
-
 from .dbproto import StructuredMemberRole
 from .dbproto import StructuredGroupCall
 from .dbproto import StructuredGroupDataV1
@@ -449,7 +448,6 @@ def get_mms_records(
     mms_records = []
 
     reaction_expr = versioninfo.get_reactions_query_column()
-
     quote_mentions_expr = versioninfo.get_quote_mentions_query_column()
 
     qry = db.execute(
@@ -587,7 +585,9 @@ def process_backup(backup_dir, output_dir):
     addressbook = make_addressbook(db, versioninfo)
 
     # Start by getting the Threads from the database
-    query = db.execute("SELECT _id, recipient_ids FROM thread")
+    recipient_id_expr = versioninfo.get_thread_recipient_id_column()
+
+    query = db.execute(f"SELECT _id, {recipient_id_expr} FROM thread")
     threads = query.fetchall()
 
     # Combine the recipient objects and the thread info into Thread objects

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -20,7 +20,6 @@ from .dbproto import StructuredGroupCall
 from .dbproto import StructuredGroupDataV1
 from .dbproto import StructuredGroupDataV2
 from .dbproto import StructuredMentions
-from .dbproto import StructuredReaction
 from .dbproto import StructuredReactions
 
 from .addressbook import make_addressbook
@@ -36,7 +35,6 @@ from .models import Mention
 from .models import MMSMessageRecord
 from .models import Quote
 from .models import Reaction
-from .models import Recipient
 from .models import SMSMessageRecord
 from .models import Thread
 

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -19,17 +19,16 @@ from .html_colors import get_color
 from .html_colors import list_colors
 from .models import MMSMessageRecord
 from .models import Thread
-from .types import (
-    get_named_message_type,
-    is_inbox_type,
-    is_incoming_call,
-    is_joined_type,
-    is_missed_call,
-    is_outgoing_call,
-    is_group_call,
-    is_key_update,
-    is_group_ctrl,
-)
+from .types import get_named_message_type
+from .types import is_group_call
+from .types import is_group_ctrl
+from .types import is_group_v1_migration_event
+from .types import is_inbox_type
+from .types import is_incoming_call
+from .types import is_joined_type
+from .types import is_key_update
+from .types import is_missed_call
+from .types import is_outgoing_call
 
 logger = logging.getLogger(__name__)
 
@@ -236,6 +235,8 @@ def dump_thread(thread: Thread, output_dir: str):
             event_data = format_event_data_group_update(
                 msg.data
             )  # "Group update (v2)"
+        elif is_group_v1_migration_event(msg._type):
+            continue
 
         # Deal with quoted messages
         quote = {}

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -11,6 +11,8 @@ import datetime as dt
 
 from typing import Any
 from typing import Dict
+from typing import List
+
 from emoji import emoji_lis as emoji_list
 from jinja2 import Environment
 from jinja2 import PackageLoader
@@ -149,6 +151,29 @@ def is_empty_message(msg: Dict[str, Any]) -> bool:
         or msg["isAllEmoji"]
         or msg["attachments"]
     )
+
+
+def filter_date_messages(
+    messages: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+
+    new_messages = []
+    if not messages:
+        return new_messages
+
+    if len(messages) == 1 and messages[0]["date_msg"]:
+        return new_messages
+
+    a, b = iter(messages), iter(messages)
+    next(b, None)
+    for m1, m2 in zip(a, b):
+        if m1["date_msg"] and m2["date_msg"]:
+            continue
+        new_messages.append(m1)
+
+    if not m2["date_msg"]:
+        new_messages.append(m2)
+    return new_messages
 
 
 def dump_thread(thread: Thread, output_dir: str):
@@ -320,6 +345,10 @@ def dump_thread(thread: Thread, output_dir: str):
             continue
 
         simple_messages.append(out)
+
+    # Filter out repeated date change messages with no actual messages in
+    # between
+    simple_messages = filter_date_messages(simple_messages)
 
     if not simple_messages:
         return

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -9,6 +9,8 @@ License: See LICENSE file.
 import logging
 import datetime as dt
 
+from typing import Any
+from typing import Dict
 from emoji import emoji_lis as emoji_list
 from jinja2 import Environment
 from jinja2 import PackageLoader
@@ -135,6 +137,18 @@ def format_event_data_group_update(data):
         event_data.member_lists.append(member_list)
 
     return event_data
+
+
+def is_empty_message(msg: Dict[str, Any]) -> bool:
+    return not (
+        msg["body"]
+        or (not msg["event_data"] is None)
+        or msg["isCall"]
+        or msg["quote"]
+        or msg["reactions"]
+        or msg["isAllEmoji"]
+        or msg["attachments"]
+    )
 
 
 def dump_thread(thread: Thread, output_dir: str):
@@ -301,6 +315,9 @@ def dump_thread(thread: Thread, output_dir: str):
                         "time_received": r.time_received,
                     }
                 )
+
+        if is_empty_message(out):
+            continue
 
         simple_messages.append(out)
 

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -267,6 +267,7 @@ def dump_thread(thread: Thread, output_dir: str):
         # Create message dictionary
         aR = msg.addressRecipient
         out = {
+            "date_msg": False,
             "isAllEmoji": all_emoji,
             "isGroup": thread.is_group,
             "isCall": is_event,

--- a/signal2html/templates/thread.html
+++ b/signal2html/templates/thread.html
@@ -282,7 +282,7 @@
   <body>
     <div class="message-box">
 {% for msg in messages %}
-  {% if "date_msg" in msg %}
+  {% if msg.date_msg %}
       <div class="msg msg-date-change">
         <p>
           {{ msg.body }}

--- a/signal2html/types.py
+++ b/signal2html/types.py
@@ -17,6 +17,7 @@ JOINED_TYPE = 4
 UNSUPPORTED_MESSAGE_TYPE = 5
 INVALID_MESSAGE_TYPE = 6
 MISSED_VIDEO_CALL_TYPE = 8
+GV1_MIGRATION_TYPE = 9
 INCOMING_VIDEO_CALL_TYPE = 10
 OUTGOING_VIDEO_CALL_TYPE = 11
 GROUP_CALL_TYPE = 12
@@ -84,6 +85,10 @@ def is_key_update(_type):
     return _type & KEY_UPDATE_TYPE_BIT == KEY_UPDATE_TYPE_BIT
 
 
+def is_group_v1_migration_event(_type) -> bool:
+    return _type == GV1_MIGRATION_TYPE
+
+
 def is_group_ctrl(_type):
     return _type & GROUP_CTRL_TYPE_BIT == GROUP_CTRL_TYPE_BIT
 
@@ -102,6 +107,8 @@ def get_named_message_type(_type):
             return "group-update-v2"
         else:
             return "group-update-v1"
+    elif is_group_v1_migration_event(_type):
+        return "group-update-v1"
     elif is_key_update(_type):
         return "key-update"
     elif is_outgoing_message_type(_type):

--- a/signal2html/types.py
+++ b/signal2html/types.py
@@ -2,7 +2,10 @@
 
 """Utilities for dealing with message types
 
-These are extracted from the Signal Android app source code.
+These are extracted from the Signal Android app source code, specifically this 
+file:
+
+    https://github.com/signalapp/Signal-Android/blob/master/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsColumns.java
 
 License: See LICENSE file.
 

--- a/signal2html/types.py
+++ b/signal2html/types.py
@@ -24,8 +24,8 @@ GROUP_CALL_TYPE = 12
 
 KEY_UPDATE_TYPE_BIT = 0x200
 
-GROUP_CTRL_TYPE_BIT = 0x10000
-GROUP_V2_DATA_TYPE_BIT = 0x80000
+GROUP_UPDATE_BIT = 0x10000
+GROUP_V2_BIT = 0x80000
 
 BASE_INBOX_TYPE = 20
 BASE_OUTBOX_TYPE = 21
@@ -90,11 +90,11 @@ def is_group_v1_migration_event(_type) -> bool:
 
 
 def is_group_ctrl(_type):
-    return _type & GROUP_CTRL_TYPE_BIT == GROUP_CTRL_TYPE_BIT
+    return _type & GROUP_UPDATE_BIT == GROUP_UPDATE_BIT
 
 
 def is_group_v2_data(_type):
-    return _type & GROUP_V2_DATA_TYPE_BIT == GROUP_V2_DATA_TYPE_BIT
+    return _type & GROUP_V2_BIT == GROUP_V2_BIT
 
 
 def is_joined_type(_type):

--- a/signal2html/versioninfo.py
+++ b/signal2html/versioninfo.py
@@ -49,3 +49,9 @@ class VersionInfo(object):
         """Returns a SQL expression to retrieve quote mentions in MMS messages."""
 
         return "quote_mentions" if self.are_mentions_supported() else "''"
+
+    def get_thread_recipient_id_column(self) -> str:
+        """Returns SQL expression to retrieve recipient id from thread table"""
+        return (
+            "thread_recipient_id" if self.version >= 108 else "recipient_ids"
+        )


### PR DESCRIPTION
This builds on PR #35. After the database migration to 110 I have some empty messages in my threads, so this attempts to filter these out. This in turn can lead to repeated date messages with nothing in between, so those are filtered out too now.

To be merged after #35 is merged.