### PR TITLE
Explicitly cast address to string when looking up recipient

### DIFF
--- a/signal2html/addressbook.py
+++ b/signal2html/addressbook.py
@@ -9,7 +9,6 @@ License: See LICENSE file.
 import abc
 import logging
 
-from typing import Union
 from .html_colors import get_random_color
 from .models import Recipient
 from .versioninfo import VersionInfo
@@ -218,7 +217,7 @@ class AddressbookV1(Addressbook):
 
 
 class AddressbookV2(Addressbook):
-    def get_recipient_by_address(self, address: Union[int, str]) -> Recipient:
+    def get_recipient_by_address(self, address: str) -> Recipient:
         """In this database version, all addresses are recipient_id's and
         creating them here is not expected to happen."""
 

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -92,7 +92,7 @@ def get_sms_records(db, thread, addressbook):
     for _id, address, date, date_sent, body, _type in qry_res:
 
         data = get_data_from_body(_type, body, addressbook, _id)
-        sms_auth = addressbook.get_recipient_by_address(address)
+        sms_auth = addressbook.get_recipient_by_address(str(address))
         sms = SMSMessageRecord(
             _id=_id,
             data=data,
@@ -481,7 +481,7 @@ def get_mms_records(
         decoded_reactions = get_mms_reactions(reactions, addressbook, _id)
 
         data = get_data_from_body(msg_box, body, addressbook, _id)
-        mms_auth = addressbook.get_recipient_by_address(address)
+        mms_auth = addressbook.get_recipient_by_address(str(address))
         mms = MMSMessageRecord(
             _id=_id,
             data=data,
@@ -592,7 +592,7 @@ def process_backup(backup_dir, output_dir):
 
     # Combine the recipient objects and the thread info into Thread objects
     for (_id, recipient_id) in threads:
-        recipient = addressbook.get_recipient_by_address(recipient_id)
+        recipient = addressbook.get_recipient_by_address(str(recipient_id))
         if recipient is None:
             logger.warn(f"No recipient with address {recipient_id}")
 


### PR DESCRIPTION
A recent database change made many of the "address" fields integers that refer to recipient IDs. Since we also support old database versions where the address refers to a phone number (as a string), we explicitly have to cast the new integer fields to ensure we don't end up creating fallback recipients with "unknown" addresses due to type mismatch.

Fixes #40.

P.S. @ericthegrey let me know if you're getting to many review requests. I've gotten into the habit of requesting them for each PR, but I can also imagine it's a bit much, so let me know if you'd only like to be consulted on larger changes (for instance).