### PR TITLE
Handle mentions being None

### DIFF
--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -42,7 +42,7 @@ def is_all_emoji(body):
     return len(emoji_list(body)) == len(body) and len(body) > 0
 
 
-def format_message(body, mentions={}):
+def format_message(body, mentions=None):
     """Format message by processing all characters.
 
     - Wrap emoji in <span> for styling them
@@ -50,6 +50,8 @@ def format_message(body, mentions={}):
     """
     if body is None:
         return None
+
+    mentions = mentions or {}
 
     emoji_pos = emoji_list(body)
     new_body = ""

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -51,7 +51,8 @@ def format_message(body, mentions=None):
     if body is None:
         return None
 
-    mentions = mentions or {}
+    if mentions is None:
+        mentions = {}
 
     emoji_pos = emoji_list(body)
     new_body = ""


### PR DESCRIPTION
Not sure why this was None in the first place, which may be worth investigating still. Fixes #48.

*Update:* I guess it is None when ``msg_id`` is not in ``thread.mentions``. I don't know if that's expected or not here, but if it's not an issue then I think the fix is fine.