### PR TITLE
Return None when group update data fails

### DIFF
--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -161,7 +161,7 @@ def decode_body(body):
     try:
         return base64.b64decode(body)
     except (TypeError, ValueError, binascii.Error) as e:
-        logger.warn(f"Failed to decode body for message {mid}: {str(e)}")
+        logger.warn(f"Failed to decode body for message '{body}': {str(e)}")
         return None
 
 
@@ -175,7 +175,9 @@ def get_group_call_data(rawbody, addressbook, mid):
         structured_call = StructuredGroupCall.loads(rawbody)
     except (ValueError, IndexError, TypeError) as e:
         logger.warn(
-            f"Failed to load group call data for message {mid}: {str(e)}"
+            f"Failed to load group call data for message {mid}:\n"
+            f"Message body: '{rawbody}'\n"
+            f"Error message: {str(e)}"
         )
         return []
 
@@ -215,7 +217,9 @@ def get_group_update_data_v1(rawbody, addressbook, mid):
         structured_group_data = StructuredGroupDataV1.loads(rawbody)
     except (ValueError, IndexError, TypeError) as e:
         logger.warn(
-            f"Failed to load group update data (v1) for message {mid}: {str(e)}"
+            f"Failed to load group update data (v1) for message {mid}:\n"
+            f"Message body: '{rawbody}'\n"
+            f"Error message: {str(e)}"
         )
         return None
 
@@ -295,7 +299,9 @@ def get_group_update_data_v2(rawbody, addressbook, mid):
         structured_group_data = StructuredGroupDataV2.loads(rawbody)
     except (ValueError, IndexError, TypeError) as e:
         logger.warn(
-            f"Failed to load group update data (v2) for message {mid}: {str(e)}"
+            f"Failed to load group update data (v2) for message {mid}:\n"
+            f"Message body: '{rawbody}'\n"
+            f"Error message: {str(e)}"
         )
         return None
 
@@ -389,7 +395,9 @@ def get_mms_mentions(encoded_mentions, addressbook, mid):
             structured_mentions = StructuredMentions.loads(encoded_mentions)
         except (ValueError, IndexError, TypeError) as e:
             logger.warn(
-                f"Failed to load quote mentions for message {mid}: {str(e)}"
+                f"Failed to load quote mentions for message {mid}:\n"
+                f"Encoded mentions: '{encoded_mentions}'\n"
+                f"Error message: {str(e)}"
             )
             return []
 
@@ -419,7 +427,9 @@ def get_mms_reactions(encoded_reactions, addressbook, mid):
             structured_reactions = StructuredReactions.loads(encoded_reactions)
         except (ValueError, IndexError, TypeError) as e:
             logger.warn(
-                f"Failed to load reactions for message {mid}: {str(e)}"
+                f"Failed to load reactions for message {mid}:\n"
+                f"Encoded reactions: '{encoded_reactions}'\n"
+                f"Error message: {str(e)}"
             )
             return []
 

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -217,7 +217,7 @@ def get_group_update_data_v1(rawbody, addressbook, mid):
         logger.warn(
             f"Failed to load group update data (v1) for message {mid}: {str(e)}"
         )
-        return []
+        return None
 
     members = dict()
     for member in structured_group_data.members:
@@ -297,7 +297,7 @@ def get_group_update_data_v2(rawbody, addressbook, mid):
         logger.warn(
             f"Failed to load group update data (v2) for message {mid}: {str(e)}"
         )
-        return []
+        return None
 
     change = structured_group_data.change
     deleted_members = []

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -218,7 +218,6 @@ def get_group_update_data_v1(rawbody, addressbook, mid):
     except (ValueError, IndexError, TypeError) as e:
         logger.warn(
             f"Failed to load group update data (v1) for message {mid}:\n"
-            f"Message body: '{rawbody}'\n"
             f"Error message: {str(e)}"
         )
         return None

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -121,7 +121,8 @@ def get_attachment_filename(_id, unique_id, backup_dir, thread_dir):
     source = os.path.abspath(os.path.join(backup_dir, fname))
     if not os.path.exists(source):
         logger.warn(
-            f"Couldn't find attachment '{source}'. Maybe it was deleted or never downloaded?"
+            f"Couldn't find attachment '{source}'. "
+            "Maybe it was deleted or never downloaded?"
         )
         return None
 

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -179,7 +179,7 @@ def get_group_call_data(rawbody, addressbook, mid):
             f"Message body: '{rawbody}'\n"
             f"Error message: {str(e)}"
         )
-        return []
+        return None
 
     timestamp = dt.datetime.fromtimestamp(structured_call.when // 1000)
     timestamp = timestamp.replace(
@@ -399,7 +399,7 @@ def get_mms_mentions(encoded_mentions, addressbook, mid):
                 f"Encoded mentions: '{encoded_mentions}'\n"
                 f"Error message: {str(e)}"
             )
-            return []
+            return {}
 
         for structured_mention in structured_mentions.mentions:
             recipient = addressbook.get_recipient_by_uuid(

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -177,7 +177,6 @@ def get_group_call_data(rawbody, addressbook, mid):
     except (ValueError, IndexError, TypeError) as e:
         logger.warn(
             f"Failed to load group call data for message {mid}:\n"
-            f"Message body: '{rawbody}'\n"
             f"Error message: {str(e)}"
         )
         return None
@@ -301,7 +300,6 @@ def get_group_update_data_v2(rawbody, addressbook, mid):
     except (ValueError, IndexError, TypeError) as e:
         logger.warn(
             f"Failed to load group update data (v2) for message {mid}:\n"
-            f"Message body: '{rawbody}'\n"
             f"Error message: {str(e)}"
         )
         return None
@@ -399,7 +397,6 @@ def get_mms_mentions(encoded_mentions, addressbook, mid):
     except (ValueError, IndexError, TypeError) as e:
         logger.warn(
             f"Failed to load quote mentions for message {mid}:\n"
-            f"Encoded mentions: '{encoded_mentions}'\n"
             f"Error message: {str(e)}"
         )
         return mentions
@@ -431,7 +428,6 @@ def get_mms_reactions(encoded_reactions, addressbook, mid):
     except (ValueError, IndexError, TypeError) as e:
         logger.warn(
             f"Failed to load reactions for message {mid}:\n"
-            f"Encoded reactions: '{encoded_reactions}'\n"
             f"Error message: {str(e)}"
         )
         return reactions

--- a/signal2html/dbproto.py
+++ b/signal2html/dbproto.py
@@ -5,6 +5,11 @@
 
 These classes are used to extract values in the database encoded as protobuf messages.
 
+Signal protobuf definitions are defined in these directories:
+
+    https://github.com/signalapp/Signal-Android/tree/master/libsignal/service/src/main/proto
+    https://github.com/signalapp/Signal-Android/tree/master/app/src/main/proto
+
 License: See LICENSE file.
 """
 

--- a/signal2html/dbproto.py
+++ b/signal2html/dbproto.py
@@ -113,5 +113,5 @@ class StructuredGroupV2State:
 @message
 @dataclass
 class StructuredGroupDataV2:
-    change: StructuredGroupV2Change = field(2)
-    state: StructuredGroupV2State = field(3)
+    change: StructuredGroupV2Change = optional_field(2)
+    state: StructuredGroupV2State = optional_field(3)

--- a/signal2html/html.py
+++ b/signal2html/html.py
@@ -238,7 +238,7 @@ def dump_thread(thread: Thread, output_dir: str):
         elif is_key_update(msg._type):
             is_event = True
             event_data = format_message(msg.addressRecipient.name)
-        elif is_group_ctrl(msg._type):
+        elif is_group_ctrl(msg._type) and not msg.data is None:
             is_event = True
             event_data = format_event_data_group_update(
                 msg.data


### PR DESCRIPTION
This is a cosmetic fix that ensures the script can continue, but doesn't address why the parsing can fail.