### PR TITLE
add filetype extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ REQUIRED = [
     'dataclasses;python_version=="3.6"',
     "pure-protobuf",
     "linkify-it-py",
+    "filetype"
 ]
 
 docs_require = []

--- a/signal2html/core.py
+++ b/signal2html/core.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import sqlite3
 import uuid
+import filetype
 
 from pathlib import Path
 
@@ -132,12 +133,19 @@ def get_attachment_filename(_id, unique_id, backup_dir, thread_dir):
         )
         return None
 
+    filetype_kind = filetype.guess(source)
+    if filetype_kind is None:
+        new_fname = fname
+    else:
+        extension = filetype_kind.extension
+        new_fname =f"Attachment_{_id}_{unique_id}.{extension}"
+
     # Copying here is a bit of a side-effect
     target_dir = os.path.abspath(os.path.join(thread_dir, "attachments"))
     os.makedirs(target_dir, exist_ok=True)
-    target = os.path.join(target_dir, fname)
+    target = os.path.join(target_dir, new_fname)
     shutil.copy(source, target)
-    url = "/".join([".", "attachments", fname])
+    url = "/".join([".", "attachments", new_fname])
     return url
 
 


### PR DESCRIPTION
Hi,

Especially for such things as "PDF" files it is more convenient if the correct file extension is directly visible there (especially for Windows users).


My patch converts the Attachment_xxxx_xxxx.bin to an Attachment_xxx_xxxx.pdf or .jpg, or .mp4, ...